### PR TITLE
restore old `#:tcp@` and `tcp^` arguments/imports, rename new

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatch-server.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatch-server.scrbl
@@ -6,6 +6,8 @@
                      web-server/private/dispatch-server-sig
                      web-server/private/util
                      web-server/private/connection-manager
+                     web-server/web-server
+                     net/tcp-sig
                      unstable/contract
                      racket/async-channel
                      racket/tcp
@@ -37,15 +39,19 @@ The @racket[dispatch-server^] signature is an alias for
  }
 }
 
-@defsignature[dispatch-server-tcp^ ()]{
+@defsignature[dispatch-server-connect^ ()]{
 
-The @racket[dispatch-server-tcp^] signature abstracts the TCP
-implementation used by the dispatch server.
+The @racket[dispatch-server-connect^] signature abstracts the conversion of connection
+ports (e.g., to implement SSL) as used by the dispatch server.
 
  @defproc[(port->real-ports [ip input-port?]
                             [op output-port?])
           (values input-port? output-port?)]{
-  Wraps the ports as necessary.
+  Converts connection ports as necessary.
+
+  The connection ports are normally TCP ports, but an alternate
+  implementation of @racket[tcp^] linked to the dispatcher can supply
+  different kinds of ports.
  }
 }
 
@@ -75,14 +81,22 @@ implementation used by the dispatch server.
 The @racketmodname[web-server/private/dispatch-server-unit] module
 provides the unit that actually implements a dispatching server.
 
-@defthing[dispatch-server@ (unit/c (import dispatch-server-tcp^
-                                           dispatch-server-config^) 
-                                   (export dispatch-server^))]{
+@defthing[dispatch-server-with-connect@ (unit/c (import tcp^
+                                                        dispatch-server-connect^
+                                                        dispatch-server-config^) 
+                                                (export dispatch-server^))]{
  Runs the dispatching server config in a very basic way, except that it uses
  @secref["connection-manager"] to manage connections.
-}
+
+@history[#:added "1.1"]}
 
 }
+
+@defthing[dispatch-server@ (unit/c (import tcp^
+                                           dispatch-server-config^) 
+                                   (export dispatch-server^))]{
+ Like @racket[dispatch-server-with-connect@], but using @racket[raw:dispatch-server-connect@].}
+
 
 @section{Threads and Custodians}
 

--- a/web-server-doc/web-server/scribblings/launch.scrbl
+++ b/web-server-doc/web-server/scribblings/launch.scrbl
@@ -10,9 +10,12 @@
                      web-server/private/dispatch-server-unit
                      web-server/private/dispatch-server-sig
                      web-server/dispatchers/dispatch
+                     net/tcp-sig
+                     racket/tcp
                      racket/async-channel
                      unstable/contract
                      web-server/configuration/configuration-table)
+          (prefix-in raw: (for-label net/tcp-unit))
           (prefix-in files: (for-label web-server/dispatchers/dispatch-files)))
 
 @defmodule[web-server/web-server]{
@@ -22,7 +25,11 @@ This module provides functions for launching dispatching servers.
 @defproc[(serve [#:dispatch dispatch dispatcher/c]
                 [#:confirmation-channel confirmation-channel (or/c false/c async-channel?) #f]
                 [#:connection-close? connection-close? boolean? #f]
-                [#:tcp@ tcp@ (unit/c (import) (export dispatch-server-tcp^)) raw:tcp@]
+                [#:dispatch-server-connect@ dispatch-server-connect@
+                                            (unit/c (import)
+                                                    (export dispatch-server-connect^))
+                                            raw:dispatch-server-connect@]
+                [#:tcp@ tcp@ (unit/c (import) (export tcp^)) raw:tcp@]
                 [#:port port tcp-listen-port? 80]
                 [#:listen-ip listen-ip (or/c string? false/c) #f]
                 [#:max-waiting max-waiting integer? 511]
@@ -34,8 +41,13 @@ This module provides functions for launching dispatching servers.
  If @racket[connection-close?] is @racket[#t], then every connection is closed after one
  request. Otherwise, the client decides based on what HTTP version it uses.
  
- The @racket[#:tcp@] keyword is provided for building an SSL server. See @secref["faq:https"].
-}
+ The @racket[#:dispatch-server-connect@] argument supports the conversion of raw connections;
+ for example, @racket[make-ssl-connect@] produces a unit to serve SSL by converting
+ raw TCP ports to SSL ports; see also @secref["faq:https"].
+ The @racket[#:tcp@] argument supports replacing TCP connections with other kinds of connections (and
+  was formerly recommended for SLL support). Beware that the server expects the @racket[tcp-accept] operation
+  from @racket[tcp@] to be effectively atomic; new connections are not accepted while @racket[tcp-accept]
+  is in progress.
 
 Here's an example of a simple web server that serves files
 from a given path:
@@ -52,11 +64,17 @@ from a given path:
    #:port 8080))
 ]
 
+@history[#:changed "1.1" @elem{Added the @racket[#:dispatch-server-connect@] argument.}]}
+
+
 @defproc[(serve/ports [#:dispatch dispatch dispatcher/c]
                       [#:confirmation-channel confirmation-channel (or/c false/c async-channel?) #f]
                       [#:connection-close? connection-close? boolean? #f]
-                      [#:tcp@ tcp@ (unit/c (import) (export dispatch-server-tcp^))
-                              raw:tcp@]
+                      [#:dispatch-server-connect@ dispatch-server-connect@
+                                                  (unit/c (import)
+                                                          (export dispatch-server-connect^))
+                                                  raw:dispatch-server-connect@]
+                      [#:tcp@ tcp@ (unit/c (import) (export tcp^)) raw:tcp@]
                       [#:ports ports (listof tcp-listen-port?) (list 80)]
                       [#:listen-ip listen-ip (or/c string? false/c) #f]
                       [#:max-waiting max-waiting integer? 511]
@@ -64,40 +82,63 @@ from a given path:
          (-> void)]{
  Calls @racket[serve] multiple times, once for each @racket[port], and returns
  a function that shuts down all of the server instances.
-}
+
+@history[#:changed "1.1" @elem{Added the @racket[#:dispatch-server-connect@] argument.}]}
+
 
 @defproc[(serve/ips+ports [#:dispatch dispatch dispatcher/c]
                           [#:confirmation-channel confirmation-channel (or/c false/c async-channel?) #f]
                           [#:connection-close? connection-close? boolean? #f]
-                          [#:tcp@ tcp@ (unit/c (import) (export dispatch-server-tcp^))
-                                  raw:tcp@]
+                          [#:dispatch-server-connect@ dispatch-server-connect@
+                                                      (unit/c (import)
+                                                              (export dispatch-server-connect^))
+                                                      raw:dispatch-server-connect@]
+                          [#:tcp@ tcp@ (unit/c (import) (export tcp^)) raw:tcp@]
                           [#:ips+ports ips+ports (listof (cons/c (or/c string? false/c) (listof tcp-listen-port?))) (list (cons #f (list 80)))]
                           [#:max-waiting max-waiting integer? 511]
                           [#:initial-connection-timeout initial-connection-timeout integer? 60])
          (-> void)]{
  Calls @racket[serve/ports] multiple times, once for each @racket[ip], and returns
  a function that shuts down all of the server instances.
-}
+
+@history[#:changed "1.1" @elem{Added the @racket[#:dispatch-server-connect@] argument.}]}
+
                   
 @defproc[(serve/web-config@ [config@ (unit/c (import) (export web-config^))]
-                            [#:tcp@ tcp@ (unit/c (import) (export dispatch-server-tcp^))
+                            [#:dispatch-server-connect@ dispatch-server-connect@
+                                                        (unit/c (import)
+                                                                (export dispatch-server-connect^))
+                                                        raw:dispatch-server-connect@]
+                            [#:tcp@ tcp@ (unit/c (import) (export tcp^))
                                     raw:tcp@])
          (-> void)]{
  Starts the @web-server with the settings defined by the given @racket[web-config^] unit.
         
- It is very useful to combine this with @racket[configuration-table->web-config@] and @racket[configuration-table-sexpr->web-config@]:
+ Combine @racket[serve/web-config@] with @racket[configuration-table->web-config@] and @racket[configuration-table-sexpr->web-config@]:
  
  @racketblock[
   (serve/web-config@
    (configuration-table->web-config@ 
     default-configuration-table-path))]
-}
 
-@defthing[raw:tcp@ (unit/c (import) (export dispatch-server-tcp^))]{A default implementation of the dispatch server's TCP abstraction.}
+@history[#:changed "1.1" @elem{Added the @racket[#:dispatch-server-connect@] argument.}]}
 
-@defproc[(make-ssl-tcp@ [server-cert-file path-string?] 
-                        [server-key-file path-string?])
-(unit/c (import) (export dispatch-server-tcp^))]{Constructs an implementation of the dispatch server's TCP abstraction for OpenSSL.}
+
+@defthing[raw:dispatch-server-connect@ (unit/c (import) (export dispatch-server-connect^))]{
+
+A default implementation of the dispatch server's connection-conversion abstraction that performs no conversion.
+
+@history[#:added "1.1"]}
+
+
+@defproc[(make-ssl-connect@ [server-cert-file path-string?] 
+                            [server-key-file path-string?])
+         (unit/c (import) (export dispatch-server-connect^))]{
+
+Constructs an implementation of the dispatch server's connection-conversion abstraction for OpenSSL.
+
+@history[#:added "1.1"]}
+
 
 @defproc[(do-not-return) void]{
  This function does not return. If you are writing a script to load the @web-server

--- a/web-server-doc/web-server/scribblings/web-server-unit.scrbl
+++ b/web-server-doc/web-server/scribblings/web-server-unit.scrbl
@@ -4,11 +4,13 @@
 @title[#:tag "web-server-unit"]{Server Units}
 @(require (for-label web-server/web-server-sig
                      web-server/web-server-unit
+                     net/tcp-sig
                      web-server/private/dispatch-server-sig
                      web-server/private/dispatch-server-unit
                      web-server/dispatchers/dispatch
                      web-server/web-config-sig
-                     web-server/web-config-unit))
+                     web-server/web-config-unit
+                     web-server/web-server))
 
 @section[#:tag "ws-sig" #:style 'hidden]{Signature}
 
@@ -32,10 +34,10 @@
 
 @section[#:tag "ws-unit" #:style 'hidden]{Unit}
 
-@defmodule[web-server/web-server-unit]{
+@defmodule[web-server/web-server-unit]
 
-@defthing[web-server@ (unit/c (web-config^ dispatch-servertcp^)
-                              (web-server^))]{
+@defthing[web-server-with-connect@ (unit/c (web-config^ tcp^ dispatch-server-connect^)
+                                           (web-server^))]{
 
 Uses the @racket[web-config^] to construct a @racket[dispatcher/c]
 function that sets up one virtual host dispatcher, for each virtual
@@ -54,6 +56,11 @@ operations:
 
 Using this @racket[dispatcher/c], it loads a dispatching server that provides @racket[serve]
 and @racket[serve-ports] functions that operate as expected.
-}
 
-}
+@history[#:added "1.1"]}
+
+
+@defthing[web-server@ (unit/c (web-config^ tcp^)
+                              (web-server^))]{
+
+Like @racket[web-server@], but using @racket[raw:dispatch-server-connect@].}

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -15,3 +15,5 @@
 (define pkg-desc "implementation (no documentation) part of \"web-server\"")
 
 (define pkg-authors '(jay))
+
+(define version "1.1")

--- a/web-server-lib/web-server/private/dispatch-server-sig.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-sig.rkt
@@ -11,7 +11,7 @@
     [serve (->* () (#:confirmation-channel (or/c false/c async-channel?)) (-> void))]
     [serve-ports (input-port? output-port? . -> . (-> void))])))
 
-(define-signature dispatch-server-tcp^
+(define-signature dispatch-server-connect^
   ((contracted
     [port->real-ports
      (-> input-port? output-port?
@@ -34,5 +34,5 @@
 
 (provide
  dispatch-server^
- dispatch-server-tcp^
+ dispatch-server-connect^
  dispatch-server-config^)

--- a/web-server-lib/web-server/private/dispatch-server-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-unit.rkt
@@ -1,138 +1,17 @@
-#lang racket/unit
-(require racket/async-channel
-         (only-in racket/tcp
-                  tcp-listen
-                  tcp-addresses
-                  tcp-close
-                  tcp-accept
-                  tcp-accept/enable-break)
-         racket/port
-         mzlib/thread)
-(require racket/format)
-(require "web-server-structs.rkt"
-         "connection-manager.rkt"
-         "dispatch-server-sig.rkt")
+#lang racket/base
+(require racket/unit
+         net/tcp-sig
+         web-server/web-server-sig
+         web-server/web-config-sig
+         web-server/private/dispatch-server-with-connect-unit
+         web-server/private/dispatch-server-sig
+         web-server/private/raw-dispatch-server-connect-unit)
 
-;; ****************************************
-(import (prefix tcp: dispatch-server-tcp^)
-        (prefix config: dispatch-server-config^))
-(export dispatch-server^)
+(provide dispatch-server@
+         dispatch-server-with-connect@)
 
-(define (async-channel-put* ac v)
-  (when ac
-    (async-channel-put ac v)))
-
-;; serve: -> -> void
-;; start the server and return a thunk to shut it down
-(define (serve #:confirmation-channel [confirmation-channel #f])
-  (define the-server-custodian (make-custodian))
-  (parameterize ([current-custodian the-server-custodian]
-                 [current-server-custodian the-server-custodian]
-                 #;[current-thread-initial-stack-size 3])
-    (define cm (start-connection-manager))
-    (thread
-     (lambda ()
-       (run-server
-        ;; This is the port argument, but because we specialize listen, it is ignored.
-        1
-        (handle-connection/cm cm)
-        #f
-        (lambda (exn)
-          ((error-display-handler)
-           (format "Connection error: ~a" (exn-message exn))
-           exn))
-        (lambda (_ mw re)
-          (with-handlers ([exn?
-                           (λ (x)
-                             (async-channel-put* confirmation-channel x)
-                             (raise x))])
-            (define listener
-              (tcp-listen config:port config:max-waiting #t config:listen-ip))
-            (let-values
-                ([(local-addr local-port end-addr end-port)
-                  (tcp-addresses listener #t)])
-              (async-channel-put* confirmation-channel local-port))
-            listener))
-        tcp-close
-        tcp-accept
-        tcp-accept/enable-break))))
-  (lambda ()
-    (custodian-shutdown-all the-server-custodian)))
-
-;; serve-ports : input-port output-port -> void
-;; returns immediately, spawning a thread to handle
-;; the connection
-;; NOTE: (GregP) should allow the user to pass in a connection-custodian
-(define (serve-ports ip op)
-  (define server-cust (make-custodian))
-  (parameterize ([current-custodian server-cust]
-                 [current-server-custodian server-cust])
-    (define connection-cust (make-custodian))
-    (define cm (start-connection-manager))
-    (define handle-connection (handle-connection/cm cm))
-    (parameterize ([current-custodian connection-cust])
-      (thread
-       (lambda ()
-         (handle-connection ip op
-                            #:port-addresses
-                            (lambda (ip)
-                              (values "127.0.0.1"
-                                      "127.0.0.1"))))))))
-
-;; handle-connection : connection-manager input-port output-port (input-port -> string string) -> void
-(define ((handle-connection/cm cm)
-         i-ip i-op
-         #:port-addresses [real-port-addresses tcp-addresses])
-  (define-values (ip op) (tcp:port->real-ports i-ip i-op))
-  (define (port-addresses some-ip)
-    (if (eq? ip some-ip)
-        (real-port-addresses i-ip)
-        (real-port-addresses ip)))
-  (define conn
-    (new-connection cm config:initial-connection-timeout
-                    ip op (current-custodian) #f))
-  (with-handlers
-      ([(λ (x)
-          ;; This error is "Connection reset by peer" and doesn't
-          ;; really indicate a problem with the server.
-          (and (exn:fail:network:errno? x)
-               (equal? (cons 54 'posix) (exn:fail:network:errno-errno x))))
-        (λ (x)
-          (kill-connection! conn))])
-    ;; HTTP/1.1 allows any number of requests to come from this input
-    ;; port. However, there is no explicit cancellation of a
-    ;; connection---the browser will just close the port. This leaves
-    ;; the Web server in the unfortunate state of config:read-request
-    ;; trying to read an HTTP and failing---with an ugly error
-    ;; message. This call to peek here will block until at least one
-    ;; character is available and then transfer to read-request. At
-    ;; that point, an error message would be reasonable because the
-    ;; request would be badly formatted or ended early. However, if
-    ;; the connection is closed, then peek will get the EOF and the
-    ;; connection will be closed. This shouldn't change any other
-    ;; behavior: read-request is already blocking, peeking doesn't
-    ;; consume a byte, etc.
-    (define the-evt
-      (choice-evt
-       (handle-evt
-        (port-closed-evt ip)
-        (λ (res)
-          (kill-connection! conn)))
-       (handle-evt
-        (peek-bytes-evt 1 0 #f ip)
-        (λ (res)
-          (cond
-            [(eof-object? res)
-             (kill-connection! conn)]
-            [else
-             (define-values
-               (req close?)
-               (config:read-request conn config:port port-addresses))
-             (set-connection-close?! conn close?)
-             (config:dispatch conn req)
-             (if (connection-close? conn)
-               (kill-connection! conn)
-               (connection-loop))])))))
-    (define (connection-loop)
-      (sync the-evt))
-    (connection-loop)))
+(define-compound-unit/infer dispatch-server@
+  (import tcp^ dispatch-server-config^)
+  (export dispatch-server^)
+  (link [([ws : web-server^]) dispatch-server-with-connect@]
+        [([dsp : dispatch-server-connect^]) raw:dispatch-server-connect@]))

--- a/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
@@ -1,0 +1,140 @@
+#lang racket/unit
+(require racket/async-channel
+         (only-in racket/tcp
+                  tcp-listen
+                  tcp-addresses
+                  tcp-close
+                  tcp-accept
+                  tcp-accept/enable-break)
+         racket/port
+         mzlib/thread
+         net/tcp-sig)
+(require racket/format)
+(require "web-server-structs.rkt"
+         "connection-manager.rkt"
+         "dispatch-server-sig.rkt")
+
+;; ****************************************
+(import tcp^
+        (prefix dispatch-server-connect: dispatch-server-connect^)
+        (prefix config: dispatch-server-config^))
+(export dispatch-server^)
+
+(define (async-channel-put* ac v)
+  (when ac
+    (async-channel-put ac v)))
+
+;; serve: -> -> void
+;; start the server and return a thunk to shut it down
+(define (serve #:confirmation-channel [confirmation-channel #f])
+  (define the-server-custodian (make-custodian))
+  (parameterize ([current-custodian the-server-custodian]
+                 [current-server-custodian the-server-custodian]
+                 #;[current-thread-initial-stack-size 3])
+    (define cm (start-connection-manager))
+    (thread
+     (lambda ()
+       (run-server
+        ;; This is the port argument, but because we specialize listen, it is ignored.
+        1
+        (handle-connection/cm cm)
+        #f
+        (lambda (exn)
+          ((error-display-handler)
+           (format "Connection error: ~a" (exn-message exn))
+           exn))
+        (lambda (_ mw re)
+          (with-handlers ([exn?
+                           (λ (x)
+                             (async-channel-put* confirmation-channel x)
+                             (raise x))])
+            (define listener
+              (tcp-listen config:port config:max-waiting #t config:listen-ip))
+            (let-values
+                ([(local-addr local-port end-addr end-port)
+                  (tcp-addresses listener #t)])
+              (async-channel-put* confirmation-channel local-port))
+            listener))
+        tcp-close
+        tcp-accept
+        tcp-accept/enable-break))))
+  (lambda ()
+    (custodian-shutdown-all the-server-custodian)))
+
+;; serve-ports : input-port output-port -> void
+;; returns immediately, spawning a thread to handle
+;; the connection
+;; NOTE: (GregP) should allow the user to pass in a connection-custodian
+(define (serve-ports ip op)
+  (define server-cust (make-custodian))
+  (parameterize ([current-custodian server-cust]
+                 [current-server-custodian server-cust])
+    (define connection-cust (make-custodian))
+    (define cm (start-connection-manager))
+    (define handle-connection (handle-connection/cm cm))
+    (parameterize ([current-custodian connection-cust])
+      (thread
+       (lambda ()
+         (handle-connection ip op
+                            #:port-addresses
+                            (lambda (ip)
+                              (values "127.0.0.1"
+                                      "127.0.0.1"))))))))
+
+;; handle-connection : connection-manager input-port output-port (input-port -> string string) -> void
+(define ((handle-connection/cm cm)
+         i-ip i-op
+         #:port-addresses [real-port-addresses tcp-addresses])
+  (define-values (ip op) (dispatch-server-connect:port->real-ports i-ip i-op))
+  (define (port-addresses some-ip)
+    (if (eq? ip some-ip)
+        (real-port-addresses i-ip)
+        (real-port-addresses ip)))
+  (define conn
+    (new-connection cm config:initial-connection-timeout
+                    ip op (current-custodian) #f))
+  (with-handlers
+      ([(λ (x)
+          ;; This error is "Connection reset by peer" and doesn't
+          ;; really indicate a problem with the server.
+          (and (exn:fail:network:errno? x)
+               (equal? (cons 54 'posix) (exn:fail:network:errno-errno x))))
+        (λ (x)
+          (kill-connection! conn))])
+    ;; HTTP/1.1 allows any number of requests to come from this input
+    ;; port. However, there is no explicit cancellation of a
+    ;; connection---the browser will just close the port. This leaves
+    ;; the Web server in the unfortunate state of config:read-request
+    ;; trying to read an HTTP and failing---with an ugly error
+    ;; message. This call to peek here will block until at least one
+    ;; character is available and then transfer to read-request. At
+    ;; that point, an error message would be reasonable because the
+    ;; request would be badly formatted or ended early. However, if
+    ;; the connection is closed, then peek will get the EOF and the
+    ;; connection will be closed. This shouldn't change any other
+    ;; behavior: read-request is already blocking, peeking doesn't
+    ;; consume a byte, etc.
+    (define the-evt
+      (choice-evt
+       (handle-evt
+        (port-closed-evt ip)
+        (λ (res)
+          (kill-connection! conn)))
+       (handle-evt
+        (peek-bytes-evt 1 0 #f ip)
+        (λ (res)
+          (cond
+            [(eof-object? res)
+             (kill-connection! conn)]
+            [else
+             (define-values
+               (req close?)
+               (config:read-request conn config:port port-addresses))
+             (set-connection-close?! conn close?)
+             (config:dispatch conn req)
+             (if (connection-close? conn)
+               (kill-connection! conn)
+               (connection-loop))])))))
+    (define (connection-loop)
+      (sync the-evt))
+    (connection-loop)))

--- a/web-server-lib/web-server/private/launch.rkt
+++ b/web-server-lib/web-server/private/launch.rkt
@@ -65,9 +65,9 @@
 (define (serve)
   (serve/web-config@ 
    configuration@
-   #:tcp@ (if (ssl)
-              (make-ssl-tcp@ (build-path (current-directory) "server-cert.pem")
-                             (build-path (current-directory) "private-key.pem"))
-              raw:tcp@)))
+   #:dispatch-server-connect@ (if (ssl)
+                                  (make-ssl-connect@ (build-path (current-directory) "server-cert.pem")
+                                                     (build-path (current-directory) "private-key.pem"))
+                                  raw:dispatch-server-connect@)))
 
 (provide serve)

--- a/web-server-lib/web-server/private/raw-dispatch-server-connect-unit.rkt
+++ b/web-server-lib/web-server/private/raw-dispatch-server-connect-unit.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+(require racket/unit
+         web-server/private/dispatch-server-sig)
+
+(provide raw:dispatch-server-connect@)
+
+(define-unit raw:dispatch-server-connect@
+  (import) (export dispatch-server-connect^)
+  (define (port->real-ports ip op)
+    (values ip op)))

--- a/web-server-lib/web-server/servlet-dispatch.rkt
+++ b/web-server-lib/web-server/servlet-dispatch.rkt
@@ -118,9 +118,9 @@
            #:listen-ip listen-ip
            #:port port-arg
            #:max-waiting max-waiting
-           #:tcp@ (if ssl?
-                      (make-ssl-tcp@ ssl-cert ssl-key)
-                      raw:tcp@)))
+           #:dispatch-server-connect@ (if ssl?
+                                          (make-ssl-connect@ ssl-cert ssl-key)
+                                          raw:dispatch-server-connect@)))
   (define serve-res (async-channel-get confirm-ch))
   (if (exn? serve-res)
       (begin

--- a/web-server-lib/web-server/web-server-unit.rkt
+++ b/web-server-lib/web-server/web-server-unit.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
-(require racket/unit)
+(require racket/unit
+         net/tcp-sig)
 (require web-server/web-server-sig
          web-server/web-config-sig
          web-server/private/dispatch-server-unit
@@ -8,6 +9,7 @@
          web-server/private/mime-types
          web-server/configuration/configuration-table-structs
          web-server/private/cache-table
+         web-server/private/raw-dispatch-server-connect-unit
          (prefix-in http: web-server/http/request))
 (require web-server/dispatchers/dispatch
          web-server/servlet/setup
@@ -23,7 +25,8 @@
          (prefix-in filter: web-server/dispatchers/dispatch-filter)
          (prefix-in lift: web-server/dispatchers/dispatch-lift))
 
-(provide web-server@)
+(provide web-server-with-connect@
+         web-server@)
 
 (define-unit web-config@->dispatch-server-config@
   (import (prefix config: web-config^))
@@ -99,7 +102,13 @@
                  #:indices (host-indices host-info))
      (lift:make (responders-file-not-found (host-responders host-info))))))
 
-(define-compound-unit/infer web-server@
-  (import dispatch-server-tcp^ web-config^)
+(define-compound-unit/infer web-server-with-connect@
+  (import tcp^ dispatch-server-connect^ web-config^)
   (export web-server^)
   (link web-config@->dispatch-server-config@ dispatch-server@))
+
+(define-compound-unit/infer web-server@
+  (import tcp^ web-config^)
+  (export web-server^)
+  (link [([ws : web-server^]) web-server-with-connect@]
+        [([dsp : dispatch-server-connect^]) raw:dispatch-server-connect@]))

--- a/web-server-lib/web-server/web-server.rkt
+++ b/web-server-lib/web-server/web-server.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
 (require racket/match
+         net/tcp-sig
+         (prefix-in raw: net/tcp-unit)
          racket/unit
          racket/async-channel
          racket/contract
@@ -8,6 +10,7 @@
          web-server/dispatchers/dispatch
          web-server/private/dispatch-server-sig
          web-server/private/dispatch-server-unit
+         web-server/private/raw-dispatch-server-connect-unit
          web-server/web-config-sig
          web-server/web-server-sig
          web-server/web-server-unit
@@ -17,7 +20,8 @@
   (->* (#:dispatch dispatcher/c)
        (#:confirmation-channel (or/c false/c async-channel?)
                                #:connection-close? boolean?
-                               #:tcp@ (unit/c (import) (export dispatch-server-tcp^))
+                               #:dispatch-server-connect@ (unit/c (import) (export dispatch-server-connect^))
+                               #:tcp@ (unit/c (import) (export tcp^))
                                #:port tcp-listen-port?
                                #:listen-ip (or/c false/c string?)
                                #:max-waiting exact-nonnegative-integer?
@@ -27,7 +31,8 @@
   (->* (#:dispatch dispatcher/c)
        (#:confirmation-channel (or/c false/c async-channel?)
                                #:connection-close? boolean?
-                               #:tcp@ (unit/c (import) (export dispatch-server-tcp^))
+                               #:dispatch-server-connect@ (unit/c (import) (export dispatch-server-connect^))
+                               #:tcp@ (unit/c (import) (export tcp^))
                                #:ports (listof tcp-listen-port?)
                                #:listen-ip (or/c false/c string?)
                                #:max-waiting exact-nonnegative-integer?
@@ -37,40 +42,37 @@
   (->* (#:dispatch dispatcher/c)
        (#:confirmation-channel (or/c false/c async-channel?)
                                #:connection-close? boolean?
-                               #:tcp@ (unit/c (import) (export dispatch-server-tcp^))
+                               #:dispatch-server-connect@ (unit/c (import) (export dispatch-server-connect^))
+                               #:tcp@ (unit/c (import) (export tcp^))
                                #:ips+ports (listof (cons/c (or/c false/c string?)
                                                            (listof tcp-listen-port?)))
                                #:max-waiting exact-nonnegative-integer?
                                #:initial-connection-timeout number?)
        (-> void))]
- [raw:tcp@ (unit/c (import) (export dispatch-server-tcp^))]
- [make-ssl-tcp@ 
+ [raw:dispatch-server-connect@ (unit/c (import) (export dispatch-server-connect^))]
+ [make-ssl-connect@ 
   (-> path-string? path-string?
-      (unit/c (import) (export dispatch-server-tcp^)))]
+      (unit/c (import) (export dispatch-server-connect^)))]
  [do-not-return (-> void)]
  [serve/web-config@ 
   (->*
    ((unit/c (import) (export web-config^)))
-   (#:tcp@ (unit/c (import) (export dispatch-server-tcp^)))
+   (#:dispatch-server-connect@ (unit/c (import) (export dispatch-server-connect^))
+    #:tcp@ (unit/c (import) (export tcp^)))
    (-> void?))])
 
-(define (make-ssl-tcp@ server-cert-file server-key-file)
+(define (make-ssl-connect@ server-cert-file server-key-file)
   (define the-ctxt
     (ssl-make-server-context))
   (ssl-load-certificate-chain! the-ctxt server-cert-file)
   (ssl-load-private-key! the-ctxt server-key-file)
-  (define-unit ssl:tcp@
-    (import) (export dispatch-server-tcp^)
+  (define-unit ssl:dispatch-server-connect@
+    (import) (export dispatch-server-connect^)
     (define (port->real-ports ip op)
       (ports->ssl-ports	ip op
                         #:mode 'accept
                         #:context the-ctxt)))
-  ssl:tcp@)
-
-(define-unit raw:tcp@
-  (import) (export dispatch-server-tcp^)
-  (define (port->real-ports ip op)
-    (values ip op)))
+  ssl:dispatch-server-connect@)
 
 (define (do-not-return)
   (semaphore-wait (make-semaphore 0)))
@@ -79,6 +81,7 @@
          #:dispatch dispatch
          #:confirmation-channel [confirmation-channel #f]
          #:connection-close? [connection-close? #f]
+         #:dispatch-server-connect@ [dispatch-server-connect@ raw:dispatch-server-connect@]
          #:tcp@ [tcp@ raw:tcp@]
          #:port [port 80]
          #:listen-ip [listen-ip #f]
@@ -87,11 +90,13 @@
   (define read-request 
     (http:make-read-request
      #:connection-close? connection-close?))
+  (define-unit-binding a-dispatch-server-connect@
+    dispatch-server-connect@ (import) (export dispatch-server-connect^))
   (define-unit-binding a-tcp@
-    tcp@ (import) (export dispatch-server-tcp^))
+    tcp@ (import) (export tcp^))
   (define-compound-unit/infer dispatch-server@/tcp@
     (import dispatch-server-config^)
-    (link a-tcp@ dispatch-server@)
+    (link a-dispatch-server-connect@ a-tcp@ dispatch-server@)
     (export dispatch-server^))
   (define-values/invoke-unit
     dispatch-server@/tcp@
@@ -104,6 +109,7 @@
          #:dispatch dispatch
          #:confirmation-channel [confirmation-channel #f]
          #:connection-close? [connection-close? #f]
+         #:dispatch-server-connect@ [dispatch-server-connect@ raw:dispatch-server-connect@]
          #:tcp@ [tcp@ raw:tcp@]
          #:ports [ports (list 80)]
          #:listen-ip [listen-ip #f]
@@ -115,6 +121,7 @@
             #:dispatch dispatch
             #:confirmation-channel confirmation-channel
             #:connection-close? connection-close?
+            #:dispatch-server-connect@ dispatch-server-connect@
             #:tcp@ tcp@
             #:port port
             #:listen-ip listen-ip
@@ -128,6 +135,7 @@
          #:dispatch dispatch
          #:confirmation-channel [confirmation-channel #f]
          #:connection-close? [connection-close? #f]
+         #:dispatch-server-connect@ [dispatch-server-connect@ raw:dispatch-server-connect@]
          #:tcp@ [tcp@ raw:tcp@]
          #:ips+ports [ips+ports (list (cons #f (list 80)))]
          #:max-waiting [max-waiting 511]
@@ -139,6 +147,7 @@
              #:dispatch dispatch
              #:confirmation-channel confirmation-channel
              #:connection-close? connection-close?
+             #:dispatch-server-connect@ dispatch-server-connect@
              #:tcp@ tcp@
              #:ports ports
              #:listen-ip listen-ip
@@ -149,9 +158,13 @@
     (for-each apply shutdowns)))
 
 ; serve/config@ : configuration -> (-> void)
-(define (serve/web-config@ config@ #:tcp@ [tcp@ raw:tcp@])
+(define (serve/web-config@ config@ 
+                           #:dispatch-server-connect@ [dispatch-server-connect@ raw:dispatch-server-connect@]
+                           #:tcp@ [tcp@ raw:tcp@])
+  (define-unit-binding a-dispatch-server-connect@
+    dispatch-server-connect@ (import) (export dispatch-server-connect^))
   (define-unit-binding a-tcp@
-    tcp@ (import) (export dispatch-server-tcp^))
+    tcp@ (import) (export tcp^))
   (define-unit m@ (import web-server^) (export)
     (init-depend web-server^)
     (serve))
@@ -159,5 +172,5 @@
   (invoke-unit
    (compound-unit/infer
     (import)
-    (link a-tcp@ c@ web-server@ m@)
+    (link a-dispatch-server-connect@ a-tcp@ c@ web-server-with-connect@ m@)
     (export))))


### PR DESCRIPTION
These changes restore compatibility with the v6.1.1 release while preserving corrected HTTPS support and the new connection-conversion hook.

Since the release and current development version are mutually incompatible, the changes here favor the release, changing the names of arguments and signatures added since v6.1.1.

The `web-server@` and `dispatch-server@` units have the same imports as before, while new `web-server-with-connect@` and `dispatch-server-with-connect@` units import the new hook. (Backward compatibility would be easier and nicer if the unit system supported optional imports with default implementations.)