### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -7,7 +7,6 @@
 	       "net-lib"
                "compatibility-lib"
                "scribble-text-lib"
-               "unstable-list-lib"
                "unstable-contract-lib"
                "parser-tools-lib"))
 (define build-deps '("rackunit-lib"))

--- a/web-server-lib/web-server/http/id-cookie.rkt
+++ b/web-server-lib/web-server/http/id-cookie.rkt
@@ -1,12 +1,12 @@
 #lang racket/base
-(require unstable/bytes
-         net/base64
+(require net/base64
          net/cookie
          racket/match
          racket/file
          racket/contract
          web-server/http
-         web-server/stuffers/hmac-sha1)
+         web-server/stuffers/hmac-sha1
+         web-server/private/util)
 
 (define (substring* s st en)
   (substring s st (+ (string-length s) en)))

--- a/web-server-lib/web-server/private/util.rkt
+++ b/web-server-lib/web-server/private/util.rkt
@@ -5,11 +5,9 @@
          unstable/contract
          racket/serialize
          net/url-structs)
-(require unstable/bytes
-         unstable/contract)
+(require unstable/contract)
 (provide
  (all-from-out
-  unstable/bytes
   unstable/contract)
  list-prefix?)
 
@@ -89,6 +87,30 @@
  [path-without-base (path-string? path-string? . -> . (listof path-piece?))]
  [directory-part (path-string? . -> . path?)]
  [build-path-unless-absolute (path-string? path-string? . -> . path?)])
+
+;; --
+
+(define (read/bytes bs)
+  (read (open-input-bytes bs)))
+;; Eli: This is a really bad name for something that is often called
+;;   `read-from-string', or `read-from-bytes' in this case.  I first read it as
+;;   "read with bytes".  Regardless, I see little point in composing two
+;;   functions where the two names are clear enough -- you might consider
+;;   looking at the version in CL.
+;; Ryan: I agree. More useful would be a version that checked that the
+;; bytes contains only one S-expr and errors otherwise.
+
+(define (write/bytes v)
+  (define by (open-output-bytes))
+  (write v by)
+  (get-output-bytes by))
+;; Eli: Same bad name as above.  Also, is there any point in this given
+;;   (format "~s" v), and the fact that using the resulting string for printout
+;;   will get the same result.
+
+(provide/contract
+ [read/bytes (bytes? . -> . printable/c)]
+ [write/bytes (printable/c . -> . bytes?)])
 
 ;; --
 

--- a/web-server-lib/web-server/private/util.rkt
+++ b/web-server-lib/web-server/private/util.rkt
@@ -1,18 +1,16 @@
 #lang racket/base
 (require racket/contract/base
          racket/list
-         unstable/list
          unstable/contract
          racket/serialize
          net/url-structs)
 (require unstable/bytes
-         unstable/contract
-         unstable/list)
+         unstable/contract)
 (provide
  (all-from-out
   unstable/bytes
-  unstable/contract
-  unstable/list))
+  unstable/contract)
+ list-prefix?)
 
 ;; --
 

--- a/web-server-lib/web-server/private/util.rkt
+++ b/web-server-lib/web-server/private/util.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require racket/contract/base
+         racket/exn
          racket/list
          unstable/contract
          racket/serialize
@@ -32,14 +33,6 @@
 (define (network-error src fmt . args)
   (raise (make-exn:fail:network (format "~a: ~a" src (apply format fmt args))
                                 (current-continuation-marks))))
-
-;; exn->string : (or/c exn any) -> string
-(define (exn->string exn)
-  (if (exn? exn)
-      (parameterize ([current-error-port (open-output-string)])
-        ((error-display-handler) (exn-message exn) exn)
-        (get-output-string (current-error-port)))
-      (format "~s\n" exn)))
 
 (provide/contract
  [network-error (->* [symbol? string?] [] #:rest list? void?)]


### PR DESCRIPTION
Depends on Racket PR #972, which moves most of its contents to core libraries.

Moves the contents of `unstable/bytes` to this package.
