### PR TITLE
Restrict require web-server/http

### DIFF
--- a/web-server-lib/web-server/managers/manager.rkt
+++ b/web-server-lib/web-server/managers/manager.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 (require racket/contract
-         web-server/http
+         web-server/http/request-structs
          web-server/servlet/servlet-structs)
 
 (define-struct manager (create-instance 

--- a/web-server-lib/web-server/private/servlet.rkt
+++ b/web-server-lib/web-server/private/servlet.rkt
@@ -2,7 +2,7 @@
 (require racket/contract)
 (require web-server/servlet/servlet-structs
          web-server/managers/manager
-         web-server/http)
+         web-server/http/request-structs)
 
 (define servlet-prompt (make-continuation-prompt-tag 'servlet))
 (define-struct servlet (custodian namespace manager directory [handler #:mutable]))

--- a/web-server-lib/web-server/servlet/servlet-structs.rkt
+++ b/web-server-lib/web-server/servlet/servlet-structs.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 (require racket/contract
-         web-server/http)  
+         web-server/http/response-structs)  
 
 (define (real-any->response x)
   #f)


### PR DESCRIPTION
Various files in `web-server/...` require `web-server/http` solely in order to obtain definitions of the `request` and `response` structures.

Doing so brings in a whole load of web-server functionality which may not be necessary/desirable if (for example) `web-server/lang/abort-resume` is being used for its control structures -- namely serializable continuations.

Changing `(require web-server/http)` to `(require web-server/http/response-structs)` (or `request-structs`) severely prunes the dependency tree.