### PR TITLE
request-structs.rkt : don’t need all of net/url

### DIFF
--- a/web-server-lib/web-server/http/request-structs.rkt
+++ b/web-server-lib/web-server/http/request-structs.rkt
@@ -3,7 +3,7 @@
          racket/serialize
          racket/match
          racket/promise
-         net/url
+         net/url-structs
          web-server/private/util)
 
 (define-serializable-struct header (field value) #:transparent)


### PR DESCRIPTION
request-structs.rkt only requires net/url-structs (to provide `url?`).

This stops a lot of heavy, deeper requirements such as http-client, url-connect, mzssl, win32-ssl, gunzip, port, tcp to be omitted.
These are unnecessary when we’re simply manipulating request _structures_