### PR TITLE
Add wrapper for radio input in radio-group

### DIFF
--- a/web-server-doc/web-server/scribblings/formlets.scrbl
+++ b/web-server-doc/web-server/scribblings/formlets.scrbl
@@ -352,14 +352,16 @@ These @tech{formlet}s are the main combinators for form input.
 @defproc[(radio-group [l sequence?]
                       [#:attributes attrs (any/c . -> . (listof (list/c symbol? string?))) (λ (x) empty)]
                       [#:checked? checked? (any/c . -> . boolean?) (λ (x) #f)]
-                      [#:display display (any/c . -> . xexpr/c) (λ (x) x)])
+                      [#:display display (any/c . -> . xexpr/c) (λ (x) x)]
+					  [#:wrap wrap (any/c any/c . -> . xexpr/c) (λ (x y) (list x y))])
         (formlet/c any/c)]{
 
   This @tech{formlet} renders using a sequence of INPUT elements of
 RADIO type where each element gets its attributes from @racket[attrs]
 that share a single NAME. An element is checked if @racket[checked?]
-returns @racket[#t]. Elements are followed by the results of
-@racket[display]. The result of processing this formlet is a single
+returns @racket[#t]. Elements are combined with the results of 
+@racket[display] into an X-expression specified in @racket[wrap]. 
+The result of processing this formlet is a single
 element of the sequence.
 }
 

--- a/web-server-lib/web-server/formlets/input.rkt
+++ b/web-server-lib/web-server/formlets/input.rkt
@@ -130,6 +130,7 @@
                      #:kind kind
                      #:attributes [attrs (λ (x) empty)]
                      #:checked? [checked? (λ (x) #f)]
+					 #:display [display (λ (x) x)]
                      #:wrap [wrap (λ (x y) (list x y))])
   (define value->element (make-hasheq))
   (define i 0)

--- a/web-server-lib/web-server/formlets/input.rkt
+++ b/web-server-lib/web-server/formlets/input.rkt
@@ -130,7 +130,7 @@
                      #:kind kind
                      #:attributes [attrs (λ (x) empty)]
                      #:checked? [checked? (λ (x) #f)]
-                     #:display [display (λ (x) x)])
+                     #:wrap [wrap (λ (x y) (list x y))])
   (define value->element (make-hasheq))
   (define i 0)
   (define (remember! e)
@@ -160,15 +160,15 @@
              (for/list ([vn (in-range i)])
                        (define e (hash-ref value->element vn))
                        (define v (number->string vn))
-                       (list
-                        `(input ([name ,name]
-                                 [type ,kind]
-                                 [value ,v]
-                                 ,@(if (checked? e)
-                                       '([checked "true"])
-                                       empty)
-                                 ,@(attrs e)))
-                        (display e))))))))
+					   (wrap 
+						 `(input ([name ,name]
+								  [type ,kind]
+								  [value ,v]
+								  ,@(if (checked? e)
+									  '([checked "true"])
+									  empty)
+								  ,@(attrs e)))
+						 (display e))))))))
 
 (define (radio-group l 
                      #:attributes [attrs (λ (x) empty)]

--- a/web-server-test/tests/web-server/formlets-test.rkt
+++ b/web-server-test/tests/web-server/formlets-test.rkt
@@ -285,14 +285,15 @@
                    (test-display (radio-group 
                                   (list 1 2 3)
                                   #:display number->string 
+								  #:wrap (λ (input display) (list display input))
                                   #:checked? even?
                                   #:attributes (λ (e) (list (list 'plus-one (number->string (add1 e)))))))
-                   '((input ((name "input_0") (type "radio") (value "0") (plus-one "2")))
-                     "1"
-                     (input ((name "input_0") (type "radio") (value "1") (checked "true") (plus-one "3")))
+                   '("1"
+					 (input ((name "input_0") (type "radio") (value "0") (plus-one "2")))
                      "2"
-                     (input ((name "input_0") (type "radio") (value "2") (plus-one "4")))
-                     "3"))
+                     (input ((name "input_0") (type "radio") (value "1") (checked "true") (plus-one "3")))
+                     "3"
+                     (input ((name "input_0") (type "radio") (value "2") (plus-one "4")))))
 
       ; checkbox-group
       (test-equal? "checkbox-group"


### PR DESCRIPTION
I replaced #:display by #:wrap (since the latter allows the former), although it is obviously not backwards-compatible. 