### PR TITLE
Update/correct radio-group contract.

### DIFF
--- a/web-server-lib/web-server/formlets/input.rkt
+++ b/web-server-lib/web-server/formlets/input.rkt
@@ -357,7 +357,7 @@
                 (-> any/c (listof (list/c symbol? string?)))
                 #:checked? (any/c . -> . boolean?)
                 #:display (any/c . -> . pretty-xexpr/c)
-                #:wrap (any/c any/c . -> . pretty-xexpr/c))
+                #:wrap (any/c any/c . -> . (listof pretty-xexpr/c)))
                . ->* .
                (formlet/c any/c))]
  [checkbox-group ((sequence?)


### PR DESCRIPTION
This fixes the wrong contract that I built: `wrap` still returns a list of x-expressions, but the contract now reflects that. 

I tried to test the contract, but couldn't get it to fail on a (clearly wrong) contract, so this is again untested. 

I will try to find a way to run tests on my own branch, since me not doing so wasted quite a bit of time. Sorry about that.