### PR TITLE
Corrected documentation for stateless "send/suspend/dispatch"

### DIFF
--- a/web-server-doc/web-server/scribblings/lang.scrbl
+++ b/web-server-doc/web-server/scribblings/lang.scrbl
@@ -43,7 +43,7 @@
 }
                
 @defproc[(send/suspend/dispatch [make-response (((request? . -> . any) . -> . string?) . -> . response?)])
-         request?]{
+         any]{
  Like @racket[send/suspend/url/dispatch] but with a string URL representation.
 }
 


### PR DESCRIPTION
Changed the contract on the result to "any" (from "request?").