### PR TITLE
Weaken the contract on response-output to permit any return value

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -173,7 +173,7 @@ Here is an example typical of what you will find in many applications:
             [seconds number?]
             [mime (or/c false/c bytes?)]
             [headers (listof header?)]
-            [output (output-port? . -> . void)])]{
+            [output (output-port? . -> . any)])]{
 
 An HTTP response where @racket[output] produces the body by writing to
 the output port. @racket[code] is the response code, @racket[message]
@@ -214,6 +214,10 @@ Examples:
                       #"http://racket-lang.org/download"))
    void)
  ]
+
+@history[#:changed "1.2"
+         @elem{Contract on @racket[output] weaked to allow @racket[any]
+               as the result (instead of demanding @racket[void?]).}]
 }
 
 @defproc[(response/full [code number?] [message bytes?] [seconds number?] [mime (or/c false/c bytes?)]
@@ -236,7 +240,7 @@ Examples:
  ]
 }
                    
-@defproc[(response/output [output (-> output-port? void?)]
+@defproc[(response/output [output (-> output-port? any)]
                           [#:code code number? 200]
                           [#:message message bytes? #"Okay"]
                           [#:seconds seconds number? (current-seconds)]
@@ -245,6 +249,10 @@ Examples:
          response?]{
 Equivalent to
 @racketblock[(response code message seconds mime-type headers output)]
+
+@history[#:changed "1.2"
+         @elem{Contract on @racket[output] weaked to allow @racket[any]
+               as the result (instead of demanding @racket[void?]).}]
 }
 
 @defthing[TEXT/HTML-MIME-TYPE bytes?]{Equivalent to @racket[#"text/html; charset=utf-8"].}

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -14,4 +14,4 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.1")
+(define version "1.2")

--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -36,9 +36,9 @@
           [seconds number?]
           [mime (or/c false/c bytes?)]
           [headers (listof header?)]
-          [output (output-port? . -> . void)])]
+          [output (output-port? . -> . any)])]
  [response/full (-> number? bytes? number? (or/c false/c bytes?) (listof header?) (listof bytes?) response?)]
- [response/output (->* ((-> output-port? void?))
+ [response/output (->* ((-> output-port? any))
                        (#:code number?
                         #:message bytes?
                         #:seconds number?


### PR DESCRIPTION
The contract on `response/output` demands that the provided function returns `void?`, which is needlessly restrictive, since it always ignores the result. Furthermore, this contract is actually even more pointless: it isn’t even enforced unless you use the `response/output` helper. The `response` struct is supposed to have the same contract on its `output`  field, but a typo in the contract uses `void` instead of `void?`, which permits any (single-valued) result.

This restriction is both annoying and actually confusing to people. It has come up on the mailing list before, and recently it came up again on the IRC channel. Furthermore, one of [Matt Might’s blog posts](http://matt.might.net/articles/low-level-web-in-racket/) actually depends on this permissive behavior of `response`, which is especially awkward given that it will fail if you change `response` to `response/output`.

This simply weakens the contract to what I think it probably should be, `(output-port? . -> . any)`, removing the possibility for confusion and being generally more permissive without any loss of safety.