### PR TITLE
Use RFC 6265 cookies from net-cookies

### DIFF
--- a/web-server-doc/info.rkt
+++ b/web-server-doc/info.rkt
@@ -3,6 +3,7 @@
 (define collection 'multi)
 
 (define build-deps '("net-doc"
+                     "net-cookies"
                      "rackunit-doc"
                      "compatibility-doc"
                      "db-doc"

--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -294,10 +294,11 @@ transmission that the server @bold{will not catch}.}
    Constructs a cookie with the appropriate fields.
 
    This is a wrapper around @racket[make-cookie] from @racketmodname[net/cookies/server]
-   for backwords compatability. The @racket[comment] argument is ignored.
+   for backwards compatability. The @racket[comment] argument is ignored.
    If @racket[expires] is given as a string, it should match
    @link["https://tools.ietf.org/html/rfc7231#section-7.1.1.2"]{RFC 7231, Section 7.1.1.2},
    in which case it will be converted to a @racket[date?] value.
+   If conversion fails, an @racket[exn:fail:contract?] is raised.
  }
 
  @defproc[(cookie->header [c cookie?]) header?]{
@@ -401,7 +402,7 @@ available (@racket[make-secret-salt/file]),
  @defproc*[([(request-id-cookie [request request?]
                                 [#:name name (and/c string? cookie-name?)]
                                 [#:key secret-salt bytes?]
-                                [#:timeout timeout +inf.0])
+                                [#:timeout timeout number? +inf.0])
              (or/c #f (and/c string? cookie-value?))]
             [(request-id-cookie [name (and/c string? cookie-name?)]
                                 [secret-salt bytes?]

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -5,6 +5,7 @@
 (define deps '("srfi-lite-lib"
                ("base" #:version "6.2.900.15")
 	       "net-lib"
+               "net-cookies"
                "compatibility-lib"
                "scribble-text-lib"
                "parser-tools-lib"))

--- a/web-server-lib/web-server/http/cookie-parse.rkt
+++ b/web-server-lib/web-server/http/cookie-parse.rkt
@@ -1,147 +1,34 @@
 #lang racket/base
-(require racket/port
-         racket/match
-         web-server/http/request-structs
-         net/cookie
+
+(require web-server/http/request-structs
+         net/cookies/common
+         net/cookies/server
          web-server/private/util         
          racket/contract)
+
+(provide (contract-out
+          [struct client-cookie 
+            ([name (and/c string? cookie-name?)]
+             [value (and/c string? cookie-value?)]
+             [domain (or/c #f domain-value?)]
+             [path (or/c #f path/extension-value?)])]
+          [request-cookies (-> request?
+                               (listof client-cookie?))]
+          ))
 
 (define-struct client-cookie 
   (name value domain path)
   #:prefab)
 
-(provide/contract
- [struct client-cookie 
-         ([name string?]
-          [value string?]
-          [domain (or/c false/c valid-domain?)]
-          [path (or/c false/c string?)])]
- [request-cookies (request? . -> . (listof client-cookie?))])
-
-;; ============================================================
-;; utilities for retrieving cookies
-
-(require parser-tools/lex
-         parser-tools/yacc
-         (prefix-in : parser-tools/lex-sre))
-
-#|
-   cookie          =       "Cookie:" cookie-version
-                           1*((";" | ",") cookie-value)
-   cookie-value    =       NAME "=" VALUE [";" path] [";" domain]
-   cookie-version  =       "$Version" "=" value
-   NAME            =       attr
-   VALUE           =       value
-   path            =       "$Path" "=" value
-   domain          =       "$Domain" "=" value
-
-   value          = token | quoted-string
-
-   token          = 1*<any CHAR except CTLs or tspecials>
-
-   quoted-string  = ( <"> *(qdtext) <"> )
-   qdtext         = <any TEXT except <">>
-|#
-(define-lex-abbrevs
-  (illegal (char-set "()<>@:/[]?{}"))
-  (tspecial (:or (char-set "()<>@,;\\\"/[]?={}") whitespace #\tab))
-  (token-char (:- any-char tspecial iso-control)))
-
-(define-tokens regular (TOKEN QUOTED-STRING ILLEGAL))
-(define-empty-tokens keywords (EQUALS SEMI COMMA PATH DOMAIN VERSION EOF))
-
-(define lex-cookie
-  (lexer-src-pos
-   [(eof) (token-EOF)]
-   [whitespace (return-without-pos (lex-cookie input-port))]
-   ["=" (token-EQUALS)]
-   [";" (token-SEMI)]
-   ["," (token-COMMA)]
-   [(:+ illegal) (token-ILLEGAL lexeme)]
-   ["$Path" (token-PATH)]
-   ["$Domain" (token-DOMAIN)]
-   ["$Version" (token-VERSION)]
-   [(:: #\" (:* (:or (:~ #\") "\\\"")) #\")
-    (token-QUOTED-STRING (substring lexeme 1 (- (string-length lexeme) 1)))]
-   [(:+ token-char) (token-TOKEN lexeme)]))
-
-(define current-source-name (make-parameter #f))
-
-(define (make-srcloc start-pos end-pos)
-  (list (current-source-name) 
-        (position-line start-pos)
-        (position-col start-pos)
-        (position-offset start-pos)
-        (- (position-offset end-pos) (position-offset start-pos))))
-
-(define parse-raw-cookies
-  (parser (src-pos)
-          (start items)
-          (tokens regular keywords)
-          (grammar (items [(item separator items) (cons $1 $3)]
-                          [(item) (list $1)])
-                   (separator [(COMMA) #t]
-                              [(SEMI) #t])
-                   (item [(lhs EQUALS rhs) (cons $1 $3)]
-                         ; This is not part of the spec. It is illegal
-                         [(lhs EQUALS) (cons $1 "")])
-                   (lhs [(VERSION) "$Version"]
-                        [(DOMAIN) 'domain]
-                        [(PATH) 'path]
-                        [(TOKEN) $1])
-                   (rhs [(TOKEN) $1] ; This is legal, but is subsumed by the illegal rule
-                        [(QUOTED-STRING) (regexp-replace* (regexp-quote "\\\"") $1 "\"")]
-                        ; This is not part of the spec. It is illegal
-                        [(illegal) $1])
-                   (illegal
-                    [(EQUALS) "="]
-                    [(ILLEGAL) $1]
-                    [(illegal illegal) (string-append $1 $2)]
-                    [(TOKEN) $1]))
-          (suppress) ; The illegal rule creates many conflicts
-          (end EOF)
-          (error (lambda (tok-ok? tok-name tok-value start-pos end-pos)
-                   (raise-syntax-error
-                    'parse-cookies
-                    (format 
-                     (if tok-ok? 
-                         "Did not expect token ~a"
-                         "Invalid token ~a")
-                     tok-name)
-                    (datum->syntax #f tok-value (make-srcloc start-pos end-pos)))))))
-
-(define (parse-cookie-likes ip)
-  (parse-raw-cookies (λ () (lex-cookie ip))))
-
-(define (parse-cookies str)
-  (with-input-from-string 
-      str
-    (λ () 
-      (define ip (current-input-port))
-      (port-count-lines! ip)
-      (parameterize ([current-source-name (object-name ip)])
-        (raw->cookies (parse-cookie-likes ip))))))
-
-;; raw->cookies : flat-property-list -> (listof cookie)
-(define raw->cookies
-  (match-lambda
-    [(list-rest (cons (? string? key) val) l)
-     (let loop ([l l] [c (make-client-cookie key val #f #f)])
-       (match l
-         [(list)
-          (list c)]
-         [(list-rest (cons (? string? key) val) l)
-          (list* c (loop l (make-client-cookie key val #f #f)))]
-         [(list-rest (cons 'domain val) l)
-          (loop l (struct-copy client-cookie c [domain val]))]
-         [(list-rest (cons 'path val) l)
-          (loop l (struct-copy client-cookie c [path val]))]))]))
-
-;; request-cookies* : request -> (listof cookie)
 (define (request-cookies req)
-  (define hdrs (request-headers/raw req))
-  (apply append
-         (map (compose parse-cookies bytes->string/utf-8 header-value)
-              (filter (lambda (h)
-                        (bytes-ci=? #"Cookie" (header-field h)))
-                      hdrs))))
+  (for/fold ([cookies-so-far null])
+            ([this-header (in-list (request-headers/raw req))]
+             #:when (bytes-ci=? #"Cookie"
+                                (header-field this-header)))
+    (append cookies-so-far
+            (for/list ([pr (in-list (cookie-header->alist
+                                     (header-value this-header)))])
+              (client-cookie (bytes->string/utf-8 (car pr))
+                             (bytes->string/utf-8 (cdr pr))
+                             #f
+                             #f)))))

--- a/web-server-lib/web-server/http/cookie.rkt
+++ b/web-server-lib/web-server/http/cookie.rkt
@@ -1,50 +1,94 @@
 #lang racket/base
-(require net/cookie
+
+(require net/cookies/common
+         net/cookies/server
          web-server/http/request-structs
-         web-server/http/response-structs
-         xml
-         web-server/private/xexpr
-         racket/contract)
+         racket/contract
+         racket/match
+         racket/date
+         )
 
-(provide/contract 
- [make-cookie ((cookie-name? cookie-value?)
-               (#:comment (or/c false/c string?)
-                #:domain (or/c false/c valid-domain?)
-                #:max-age (or/c false/c exact-nonnegative-integer?)
-                #:path (or/c false/c string?)
-                #:expires (or/c false/c string?)
-                #:secure? (or/c false/c boolean?))
-               . ->* . cookie?)]
- [cookie->header (cookie? . -> . header?)])
-
-(define-syntax setter
-  (syntax-rules ()
-    [(_ e)
-     e]
-    [(_ e (f arg) . more)
-     (let ([x e])
-       (setter (if arg
-                   (f x arg)
-                   x)
-               . more))]))
-
-(define (make-cookie name val
-                     #:comment [comment #f]
-                     #:domain  [domain #f]
-                     #:max-age [max-age #f]
-                     #:path    [path #f]
-                     #:expires [expires #f]
-                     #:secure? [secure? #f])
-  (setter (set-cookie name val)
-          (cookie:add-comment comment)
-          (cookie:add-domain domain)
-          (cookie:add-expires expires)
-          (cookie:add-max-age max-age)
-          (cookie:add-path path)
-          (cookie:secure secure?)))
+(provide (contract-out
+          [cookie->header (-> cookie?
+                              header?)]
+          [rename make-cookie* make-cookie
+                  (->* (cookie-name?
+                        cookie-value?)
+                       (#:comment any/c
+                        #:domain (or/c domain-value? #f)
+                        #:max-age (or/c (and/c integer? positive?) #f)
+                        #:path (or/c path/extension-value? #f)
+                        #:expires (or/c date? string? #f)
+                        #:secure? any/c
+                        #:http-only? any/c
+                        #:extension (or/c path/extension-value? #f))
+                       cookie?)]
+          ))
 
 ;; cookie->header : cookie -> header
 ;; gets the header that will set the given cookie
 (define (cookie->header cookie)
-  (make-header #"Set-Cookie" (string->bytes/utf-8 (print-cookie cookie))))
+  (header #"Set-Cookie" (cookie->set-cookie-header cookie)))
+
+(define exp-date-pregexp
+  (pregexp (string-append "(\\d\\d)\\s+";day
+                          "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s+";month
+                          "(\\d\\d\\d\\d)\\s+";year
+                          "(\\d\\d):(\\d\\d):(\\d\\d)" ;hr:min:sec
+                          )))
+
+(define (make-cookie* name
+                      value
+                      #:comment [_ #f]
+                      #:domain [domain #f]
+                      #:max-age [max-age #f]
+                      #:path [path #f]
+                      #:expires [exp-date/raw #f]
+                      #:secure? [secure? #f]
+                      #:http-only? [http-only? #f] 	 	 	 
+                      #:extension [extension #f])
+  (make-cookie name
+               value
+               #:domain domain
+               #:max-age max-age
+               #:path path
+               #:secure? (not (not secure?))
+               #:http-only? (not (not http-only?))
+               #:extension extension
+               #:expires (cond [(string? exp-date/raw)
+                                (match exp-date/raw
+                                  [(pregexp exp-date-pregexp
+                                            (list _
+                                                  (app string->number day)
+                                                  month-str
+                                                  (app string->number year)
+                                                  (app string->number hour)
+                                                  (app string->number min)
+                                                  (app string->number sec)))
+                                   (seconds->date
+                                    (find-seconds sec min hour day
+                                                  (case month-str
+                                                    [("Jan") 1]
+                                                    [("Feb") 2]
+                                                    [("Mar") 3]
+                                                    [("Apr") 4]
+                                                    [("May") 5]
+                                                    [("Jun") 6]
+                                                    [("Jul") 7]
+                                                    [("Aug") 8]
+                                                    [("Sep") 9]
+                                                    [("Oct") 10]
+                                                    [("Nov") 11]
+                                                    [("Dec") 12])
+                                                  year
+                                                  #f))]
+                                  [_ (raise-arguments-error
+                                      'make-cookie*
+                                      "invalid #:expires string"
+                                      'expected "#f, a date?, or a string conforming to RFC 7231 Section 7.1.1.2"
+                                      'given exp-date/raw)])]
+                               [else exp-date/raw])))
+
+
+
 

--- a/web-server-lib/web-server/http/cookie.rkt
+++ b/web-server-lib/web-server/http/cookie.rkt
@@ -65,27 +65,30 @@
                                                   (app string->number hour)
                                                   (app string->number min)
                                                   (app string->number sec)))
-                                   (seconds->date
-                                    (find-seconds sec min hour day
-                                                  (case month-str
-                                                    [("Jan") 1]
-                                                    [("Feb") 2]
-                                                    [("Mar") 3]
-                                                    [("Apr") 4]
-                                                    [("May") 5]
-                                                    [("Jun") 6]
-                                                    [("Jul") 7]
-                                                    [("Aug") 8]
-                                                    [("Sep") 9]
-                                                    [("Oct") 10]
-                                                    [("Nov") 11]
-                                                    [("Dec") 12])
-                                                  year
-                                                  #f))]
+                                   (with-handlers ([exn:fail? (λ (e) (failure-cont))])
+                                     (seconds->date
+                                      (find-seconds sec min hour day
+                                                    (case month-str
+                                                      [("Jan") 1]
+                                                      [("Feb") 2]
+                                                      [("Mar") 3]
+                                                      [("Apr") 4]
+                                                      [("May") 5]
+                                                      [("Jun") 6]
+                                                      [("Jul") 7]
+                                                      [("Aug") 8]
+                                                      [("Sep") 9]
+                                                      [("Oct") 10]
+                                                      [("Nov") 11]
+                                                      [("Dec") 12])
+                                                    year
+                                                    #f)
+                                      #f))]
                                   [_ (raise-arguments-error
                                       'make-cookie*
                                       "invalid #:expires string"
-                                      'expected "#f, a date?, or a string conforming to RFC 7231 Section 7.1.1.2"
+                                      'expected
+                                      "#f, a date?, or a string conforming to RFC 7231 Section 7.1.1.2"
                                       'given exp-date/raw)])]
                                [else exp-date/raw])))
 

--- a/web-server-lib/web-server/http/id-cookie.rkt
+++ b/web-server-lib/web-server/http/id-cookie.rkt
@@ -19,15 +19,15 @@
        bytes?)]
   [logout-id-cookie
    (->* [(and/c string? cookie-name?)]
-                [#:path (or/c path/extension-value? #f)
-                 #:domain (or/c domain-value? #f)]
-                cookie?)]
+        [#:path (or/c path/extension-value? #f)
+         #:domain (or/c domain-value? #f)]
+        cookie?)]
   [valid-id-cookie?
-   (-> any/c
-       #:name (and/c string? cookie-name?)
-       #:key bytes?
-       #:timeout number?
-       (or/c #f (and/c string? cookie-value?)))]
+   (->* [any/c
+         #:name (and/c string? cookie-name?)
+         #:key bytes?]
+        [#:timeout number?]
+        (or/c #f (and/c string? cookie-value?)))]
   [request-id-cookie
    (->i ([name-or-req {kw-name}
                       (if (unsupplied-arg? kw-name)
@@ -111,8 +111,8 @@
                         )
   (define-values {data key}
     (if maybe-key
-        (values maybe-key data-or-key)
-        (values data-or-key maybe-data)))
+        (values data-or-key maybe-key)
+        (values maybe-data data-or-key)))
   (define authored (current-seconds))
   (define digest
     (mac key (list authored data)))
@@ -131,7 +131,7 @@
 (define (valid-id-cookie? c
                           #:name name
                           #:key key
-                          #:timeout timeout)
+                          #:timeout [timeout +inf.0])
   (and (id-cookie? name c)
        (with-handlers ([exn:fail? (lambda (x) #f)])
          (match (if (client-cookie? c)
@@ -158,11 +158,11 @@
   (let ([name (or kw-name name-or-req)]
         [key (or kw-key maybe-key)]
         [req (or maybe-req name-or-req)])
-  (for/or ([c (in-list (request-cookies req))])
-    (valid-id-cookie? c
-                      #:name name
-                      #:key key
-                      #:timeout timeout))))
+    (for/or ([c (in-list (request-cookies req))])
+      (valid-id-cookie? c
+                        #:name name
+                        #:key key
+                        #:timeout timeout))))
 
 (define (logout-id-cookie name
                           #:path [path #f]

--- a/web-server-test/tests/web-server/http/cookies-test.rkt
+++ b/web-server-test/tests/web-server/http/cookies-test.rkt
@@ -2,10 +2,17 @@
 (require rackunit
          racket/promise
          racket/list
+         racket/match
+         racket/runtime-path
+         (for-syntax racket/base)
          net/url
+         net/cookies/common
+         (except-in net/cookies/server
+                    make-cookie)
          web-server/http/request-structs
          web-server/http/response-structs
          web-server/http/cookie
+         web-server/http/id-cookie
          web-server/http/cookie-parse)
 (provide cookies-tests)
 
@@ -17,6 +24,33 @@
 
 (define (set-header->read-header h)
   (make-header #"Cookie" (header-value h)))
+
+(define-runtime-path tmp-secret-salt-path
+  "tmp-secret-salt-path")
+
+(define-check (check-equal?/list-no-order actual expected)
+  (or (and (list? actual)
+           (list? expected)
+           (= (length actual)
+              (length expected))
+           (let loop ([actual-to-go actual]
+                      [expected-to-go expected])
+             (match expected-to-go
+               ['() (null? actual-to-go)]
+               [(cons this-expected more-expected)
+                (and (member this-expected actual-to-go)
+                     (loop (remove this-expected actual-to-go)
+                           more-expected))])))
+      (with-check-info (['actual actual]
+                        ['expected expected])
+        (fail-check))))
+
+(define-syntax (test-equal?/list-no-order stx)
+  (syntax-case stx ()
+    [(_ msg actual expected)
+     (with-syntax ([expr (syntax/loc stx (check-equal?/list-no-order actual expected))])
+       (syntax/loc stx
+         (test-case msg expr)))]))
 
 (define cookies-tests
   (test-suite
@@ -31,13 +65,13 @@
                  (cookie->header (make-cookie "name" "value"))
                  (make-header #"Set-Cookie" #"name=value"))
 
-     (test-equal? "Comment"
+     (test-equal? "Comment" 
                   (header-value (cookie->header (make-cookie "name" "value" #:comment "comment")))
-                  #"name=value; Comment=comment")
+                  #"name=value") ;comment is now ignored
 
      (test-equal? "Domain"
-                  (header-value (cookie->header (make-cookie "name" "value" #:domain ".domain")))
-                  #"name=value; Domain=.domain")
+                  (header-value (cookie->header (make-cookie "name" "value" #:domain "host.domain")))
+                  #"name=value; Domain=host.domain")
 
      (test-equal? "max-age"
                   (header-value (cookie->header (make-cookie "name" "value" #:max-age 24)))
@@ -68,61 +102,221 @@
      (test-suite
       "cookie-parse.rkt"
 
-
+      ;RFC 6265 no longer gives special meaning to "$Version" "$Path" or "$Domain"
+      
       (test-equal? "None"
                    (reqcs empty)
                    empty)
 
-      (test-equal? "Simple"
-                   (reqc #"$Version=\"1\"; name=\"value\"")
-                   (list (make-client-cookie "$Version" "1" #f #f)
-                         (make-client-cookie "name" "value" #f #f)))
+      (test-equal?/list-no-order "Simple"
+                                 (reqc #"$Version=\"1\"; name=\"value\"") 
+                                 (list (make-client-cookie "$Version" "1" #f #f)
+                                       (make-client-cookie "name" "value" #f #f)))
 
-      (test-equal? "Path"
-                   (reqc #"$Version=\"1\"; name=\"value\"; $Path=\"/acme\"")
-                   (list (make-client-cookie "$Version" "1" #f #f)
-                         (make-client-cookie "name" "value" #f "/acme")))
+      (test-equal?/list-no-order "Path"
+                                 (reqc #"$Version=\"1\"; name=\"value\"; $Path=\"/acme\"")
+                                 (list (make-client-cookie "$Version" "1" #f #f)
+                                       (make-client-cookie "$Path" "/acme" #f #f)
+                                       (make-client-cookie "name" "value" #f #f))) ;new version of request-cookies never populates path or domain
 
-      (test-equal? "Domain"
-                   (reqc #"$Version=\"1\"; name=\"value\"; $Domain=\".acme\"")
-                   (list (make-client-cookie "$Version" "1" #f #f)
-                         (make-client-cookie "name" "value" ".acme" #f)))
+      (test-equal?/list-no-order "Domain"
+                                 (reqc #"$Version=\"1\"; name=\"value\"; $Domain=\"host.acme\"")
+                                 (list (make-client-cookie "$Version" "1" #f #f)
+                                       (make-client-cookie "$Domain" "host.acme" #f #f)
+                                       (make-client-cookie "name" "value" #f #f))) ;new version of request-cookies never populates path or domain
 
-      (test-equal? "Multiple"
-                   (reqc #"$Version=\"1\"; key1=\"value1\"; key2=\"value2\"")
-                   (list (make-client-cookie "$Version" "1" #f #f)
-                         (make-client-cookie "key1" "value1" #f #f)
-                         (make-client-cookie "key2" "value2" #f #f)))
+      (test-equal?/list-no-order "Multiple"
+                                 (reqc #"$Version=\"1\"; key1=\"value1\"; key2=\"value2\"")
+                                 (list (make-client-cookie "$Version" "1" #f #f)
+                                       (make-client-cookie "key1" "value1" #f #f)
+                                       (make-client-cookie "key2" "value2" #f #f)))
 
-      (test-equal? "Multiple w/ paths & domains"
-                   (reqc #"$Version=\"1\"; key1=\"value1\"; $Path=\"/acme\"; key2=\"value2\"; $Domain=\".acme\"")
-                   (list (make-client-cookie "$Version" "1" #f #f)
-                         (make-client-cookie "key1" "value1" #f "/acme")
-                         (make-client-cookie "key2" "value2" ".acme" #f)))
+      (test-equal?/list-no-order "Multiple w/ paths & domains"
+                                 (reqc #"$Version=\"1\"; key1=\"value1\"; $Path=\"/acme\"; key2=\"value2\"; $Domain=\"host.acme\"")
+                                 (list (make-client-cookie "$Version" "1" #f #f)
+                                       (make-client-cookie "$Domain" "host.acme" #f #f)
+                                       (make-client-cookie "$Path" "/acme" #f #f)
+                                       (make-client-cookie "key1" "value1" #f #f) ;new version of request-cookies never populates path or domain
+                                       (make-client-cookie "key2" "value2" #f #f)))
 
-      (test-equal? "phpBB. PR10689"
-                   (reqc #"style_cookie=null; phpbb3_e1p9b_u=54; phpbb3_e1p9b_k=; phpbb3_e1p9b_sid=3fa8d7a7b65fbabcbe9b345861dc079a")
-                   (list (make-client-cookie "style_cookie" "null" #f #f)
-                         (make-client-cookie "phpbb3_e1p9b_u" "54" #f #f)
-                         (make-client-cookie "phpbb3_e1p9b_k" "" #f #f)
-                         (make-client-cookie "phpbb3_e1p9b_sid" "3fa8d7a7b65fbabcbe9b345861dc079a" #f #f)))
+      (test-equal?/list-no-order "phpBB. PR10689"
+                                 (reqc #"style_cookie=null; phpbb3_e1p9b_u=54; phpbb3_e1p9b_k=; phpbb3_e1p9b_sid=3fa8d7a7b65fbabcbe9b345861dc079a")
+                                 (list (make-client-cookie "style_cookie" "null" #f #f)
+                                       (make-client-cookie "phpbb3_e1p9b_u" "54" #f #f)
+                                       (make-client-cookie "phpbb3_e1p9b_k" "" #f #f)
+                                       (make-client-cookie "phpbb3_e1p9b_sid" "3fa8d7a7b65fbabcbe9b345861dc079a" #f #f)))
 
-      (test-equal? "Google"
-                   (reqc #"teaching-order=course;
-__utmz=165257760.1272597702.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)\r\n")
-                   (list (make-client-cookie "teaching-order" "course" #f #f)
-                         (make-client-cookie "__utmz" "165257760.1272597702.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)" #f #f)))
+      (test-equal?/list-no-order "Google" 
+                                 (reqc ;this is rejected if there is a \n between the cookies or if there is a trailing \r\n
+                                  (bytes-append #"teaching-order=course; "
+                                                #"__utmz=165257760.1272597702.1.1.utmcsr=(direct)"
+                                                #"|utmccn=(direct)|utmcmd=(none)"))
+                                 (list (make-client-cookie "teaching-order" "course" #f #f)
+                                       (make-client-cookie "__utmz" "165257760.1272597702.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)" #f #f)))
 
-      (let ()
-        (define in "hell\"w\"o")
-        (define out #"id=\"hell\\\"w\\\"o\"")
-        (test-check "quotes (pr14194)" header-equal?
-                    (cookie->header (make-cookie "id" in))
-                    (make-header #"Set-Cookie" out))
-        (test-equal? "quotes (pr14194)"
-                     (reqc out)
-                     (list (make-client-cookie "id" in #f #f))))))))
+      #;(let ()
+          (define in "hell\"w\"o") ;<--- this is not a cookie-value?
+          (define out #"id=\"hell\\\"w\\\"o\"")
+          (test-check "quotes (pr14194)" header-equal?
+                      (cookie->header (make-cookie "id" in))
+                      (make-header #"Set-Cookie" out))
+          (test-equal? "quotes (pr14194)"
+                       (reqc out)
+                       (list (make-client-cookie "id" in #f #f))))))
+   (test-suite
+    "RFC 6265 modifications"
 
-(module+ test
-  (require rackunit/text-ui)
-  (run-tests cookies-tests))
+    (let ([dt (date* 26 42 0 9 3 2017 4 67 #f 0 0 "UTC")])
+      (test-equal? "#:expires as string"
+                   (cookie-expires (make-cookie "my-cookie"
+                                                "my-value"
+                                                #:expires "Thu, 09 Mar 2017 00:42:26 GMT"))
+                   dt)
+      (define c
+        (make-cookie "my-cookie"
+                     "my-value"
+                     #:comment "This is ignored"
+                     #:domain "example.com"
+                     #:max-age 42
+                     #:path "/some-path"
+                     #:expires dt
+                     #:secure? 'yes
+                     #:http-only? 'yes
+                     #:extension "ext"))
+      (test-suite
+       "extra arguments to make-cookie"
+       (check-match c
+                    (cookie "my-cookie"
+                            "my-value"
+                            (? (λ (x) (equal? x dt)))
+                            42
+                            "example.com"
+                            "/some-path"
+                            #t
+                            #t
+                            "ext"))
+       (check-match (cookie->header c)
+                    (header
+                     #"Set-Cookie"
+                     (app (λ (val) (regexp-split #rx"; " val))
+                          (list-no-order #"my-cookie=my-value"
+                                         #"Expires=Thu, 09 Mar 2017 00:42:26 GMT"
+                                         #"Max-Age=42"
+                                         #"Domain=example.com"
+                                         #"Path=/some-path"
+                                         #"Secure"
+                                         #"HttpOnly"
+                                         #"ext"))))
+       )))
+
+   (test-suite
+    "id-cookie.rkt"
+
+    (test-suite
+     "make-secret-salt/file"
+     (let ([delete-salt-file
+            (λ ()
+              (when (file-exists? tmp-secret-salt-path)
+                (delete-file tmp-secret-salt-path)))])
+       (dynamic-wind delete-salt-file
+                     (λ ()
+                       (test-equal? "should only initialize once"
+                                    (make-secret-salt/file tmp-secret-salt-path)
+                                    (make-secret-salt/file tmp-secret-salt-path)))
+                     delete-salt-file)))
+       
+    (let ()
+      (define test-secret-salt
+        (bytes-append #"U;\256\0.\203Iu\3663\367\262d\220\276t\207\17^_0\240\2U\341"
+                      #"\240E\20\322\36\213\210\224\35ey\365:\332\"\e\211\262\v@y\n"
+                      #"\377\32561\364\277R\363\334Q\273\270\36\223\242\202\272\206"
+                      #"\2\355\335\343\327\211\22\24\365\377\353\340\332\e\21\312\217"
+                      #"\220\344\203\322\320\322\341\2731\e\236\230\307\246\23i\352>3,"
+                      #"\260*\2,\375DK\302S\270Q\2433v\327\272\1\16\361y\213\4\16X\345H"))
+
+      (test-suite
+       "make-id-cookie and valid-id-cookie?"
+       (test-false "reject forged"
+                   (valid-id-cookie? (client-cookie "my-id-cookie"
+                                                    "my-id-cookie=YmFLLOIDULjpLQOu1+cvMBM+m&1489023629&forged-value"
+                                                    #f #f)
+                                     #:name "my-id-cookie"
+                                     #:key test-secret-salt))
+       (let ([dt (date* 26 42 0 9 3 2017 4 67 #f 0 0 "UTC")])
+         (define kw-c
+           (make-id-cookie "my-id-cookie"
+                           "my-signed-value"
+                           #:key test-secret-salt
+                           #:domain "example.com"
+                           #:max-age 42
+                           #:path "/some-path"
+                           #:expires dt
+                           #:secure? 'yes
+                           #:http-only? 'yes
+                           #:extension "ext"))
+         (define by-pos-c
+           (make-id-cookie "my-id-cookie"
+                           test-secret-salt
+                           "my-signed-value"
+                           #:domain "example.com"
+                           #:max-age 42
+                           #:path "/some-path"
+                           #:expires dt
+                           #:secure? 'yes
+                           #:http-only? 'yes
+                           #:extension "ext"))
+         (for ([c (list kw-c by-pos-c)]
+               [convention '(keyword by-position)])
+           (with-check-info (['cookie c]
+                             ['|make-id-cookie calling convention| convention])
+             (test-not-false "infinite timeout"
+                             (valid-id-cookie? c
+                                               #:name "my-id-cookie"
+                                               #:key test-secret-salt))
+             (test-not-false "finite timeout"
+                             (valid-id-cookie? c
+                                               #:name "my-id-cookie"
+                                               #:key test-secret-salt
+                                               #:timeout (current-seconds)))
+             (test-false "reject expired"
+                         (valid-id-cookie? c
+                                           #:name "my-id-cookie"
+                                           #:key test-secret-salt
+                                           #:timeout (- (current-seconds)
+                                                        86400)))
+             ))))
+      (test-suite
+       "request-id-cookie"
+       (let ()
+         (define req
+           (make-request
+            #"GET" (string->url "http://test.com/foo")
+            (list (header #"Cookie"
+                          #"my-id-cookie=YmFLLOIDULjpLQOu1+cvMBM+m&1489023629&my-signed-value"))
+            (delay empty) #f "host" 80 "client"))
+         (test-not-false "infinite timeout"
+                         (request-id-cookie req
+                                            #:name "my-id-cookie"
+                                            #:key test-secret-salt))
+         (test-not-false "finite timeout"
+                     (request-id-cookie req
+                                        #:name "my-id-cookie"
+                                        #:key test-secret-salt
+                                        #:timeout (current-seconds)))
+         (test-not-false "finite timeout / by position"
+                     (request-id-cookie req
+                                        #:name "my-id-cookie"
+                                        #:key test-secret-salt
+                                        #:timeout (current-seconds)))
+         (test-false "reject expired"
+                     (request-id-cookie "my-id-cookie"
+                                        test-secret-salt
+                                        req
+                                        #:timeout 1089023629))
+         ))))))
+    
+
+  (module+ test
+    (require rackunit/text-ui)
+    (run-tests cookies-tests))
+  


### PR DESCRIPTION
Modifies web-server/http/cookie-parse, web-server/http/cookie,
and web-server/http/id-cookie to use net/cookies from the net-cookies
package, rather than the deprecated net/cookie.

resolves #20