### PR TITLE
Fix dispatcher/c and contract on next-dispatcher to use any

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -30,7 +30,7 @@ documentation.
 This module provides a few functions for dispatchers in general.
 
 @defthing[dispatcher/c contract?]{
- Equivalent to @racket[(connection? request? . -> . void)].
+ Equivalent to @racket[(connection? request? . -> . any)].
 }
 
 @defproc[(dispatcher-interface-version/c (any any/c)) boolean?]{
@@ -42,7 +42,7 @@ This module provides a few functions for dispatchers in general.
  request.
 }
 
-@defproc[(next-dispatcher) void]{
+@defproc[(next-dispatcher) any]{
  Raises a @racket[exn:dispatcher]
 }
 

--- a/web-server-lib/web-server/dispatchers/dispatch.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch.rkt
@@ -4,7 +4,7 @@
          web-server/http)
 
 (define dispatcher/c
-  (connection? request? . -> . void))
+  (connection? request? . -> . any))
 (define dispatcher-interface-version/c
   (symbols 'v1))
 (define-struct exn:dispatcher ())
@@ -13,5 +13,5 @@
 (provide/contract
  [dispatcher/c contract?]
  [dispatcher-interface-version/c contract?]
- [next-dispatcher (-> void)]
+ [next-dispatcher (-> any)]
  [struct exn:dispatcher ()])


### PR DESCRIPTION
The contracts had previously been written using `void` (n.b. *not* `void?`).
Similar to https://github.com/racket/web-server/pull/17