### PR TITLE
Fix formlet/c

### DIFF
--- a/web-server-doc/web-server/scribblings/formlets.scrbl
+++ b/web-server-doc/web-server/scribblings/formlets.scrbl
@@ -202,7 +202,7 @@ types. Refer to @secref["input-formlets"] for example low-level formlets using t
  Equivalent to @racket[(listof xexpr/c)]
 }
 
-@defproc[(formlet/c [content any/c] ...) contract?]{
+@defproc[(formlet/c [content contract?] ...) contract?]{
  Equivalent to @racket[(integer? . -> . 
             (values xexpr-forest/c
                     ((listof binding?) . -> . (values (coerce-contract 'formlet/c content) ...))
@@ -211,10 +211,15 @@ types. Refer to @secref["input-formlets"] for example low-level formlets using t
  A @tech{formlet}'s internal representation is a function from an initial input number
  to an @xexpr forest rendering, a processing function, and the next allowable
  input number.
+
+ (Actually, @racket[formlet/c] is a macro which avoids using @racket[dynamic->*]
+ when the number of range contracts for the processing function is known at compile time.)
 }
 
 @defthing[formlet*/c contract?]{
-  Equivalent to @racket[(formlet/c any/c ...)].
+  Similar to the contracts created by @racket[formlet/c], but uses @racket[any]
+  to avoid checking the results (or even specifying the number of results)
+  of the processing function.
 }
 
 @defproc[(pure [value any/c]) (formlet/c any/c)]{

--- a/web-server-test/tests/web-server/formlets-test.rkt
+++ b/web-server-test/tests/web-server/formlets-test.rkt
@@ -4,6 +4,7 @@
          web-server/http
          web-server/formlets
          web-server/formlets/lib)
+
 (provide all-formlets-tests)
 
 (define (run-formlet f i)
@@ -117,7 +118,21 @@
     (test-case "cross* (post-i)"
                (let ([x (random 1000)])
                  (check-equal? (third (run-formlet (cross* (text "One") (text "Two")) x))
-                               x))))
+                               x)))
+    (test-case "formlet/c"
+               (check-not-exn (λ ()
+                                (formlet/c #t))
+                              "simple use")
+               (check-not-exn (λ ()
+                                (formlet/c integer? string?))
+                              "multi-argument use")
+               (check-not-exn (λ ()
+                                (map formlet/c `(example #t #f)))
+                              "higher-order use")
+               (check-not-exn (λ ()
+                                (apply formlet/c (list string? (or/c #t #f))))
+                              "higher-order use with multiple arguments")))
+    
    
    (local [(define (->cons bf)
              (cons (binding-id bf)


### PR DESCRIPTION
The old implementation of `formlet/c` could not actually handle multiple arguments. Expressions like `(formlet/c string? number?)` produced an error because `formlet/c` attempted to use `->` to define the processing function, but only `dynamic->*` can compute the number of results at runtime. The new implementation fixes this.

The new implementation is slightly more complicated because I wanted to avoid `dynamic->*` whenever possible, since it creates slower contracts than `->`. The obvious way is to make `formlet/c` a macro, but it was previously documented as being a function. I define `formlet/c` as a macro that expands to a function when it is used in a first-class context, and I have the function handle the one-argument case (i.e. all the uses of `formlet/c` that actually worked until now) specially.

I also revised the docs to clarify that `formlet*/c` can not be implemented in terms of `formlet/c`.