### PR TITLE
Add optional finalizer procedure to flushed servlet instances

### DIFF
--- a/web-server-doc/web-server/scribblings/cache-table.scrbl
+++ b/web-server-doc/web-server/scribblings/cache-table.scrbl
@@ -23,12 +23,15 @@ functions.
 }
 
 @defproc[(cache-table-clear! [ct cache-table?]
-                             [entry-ids (or/c false/c (listof symbol?)) #f])
+                             [entry-ids (or/c false/c (listof symbol?)) #f]
+			     [finalize (-> any/c void?) void])
          void?]{
  If @racket[entry-ids] is @racket[#f], clears all entries in @racket[ct].
  Otherwise, clears only the entries with keys in @racket[entry-ids].
+ The procedure @racket[finalize] is invoked on each entry before it is cleared.
 
- @history[#:changed "6.9.0.1" "Added optional argument."]
+ @history[#:changed "6.9.0.1" "Added optional argument for list of entry keys."
+          #:changed "6.11.0.3" "Added optional argument for finalizer procedure."]
 }
 
 @defproc[(cache-table? [v any/c])

--- a/web-server-doc/web-server/scribblings/dispatch-servlets.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatch-servlets.scrbl
@@ -18,17 +18,22 @@
 @defproc[(make-cached-url->servlet
           [url->path url->path/c]
           [path->serlvet path->servlet/c])
-         (values (->* () ((or/c false/c (listof url?))) void?)
+         (values (->* () ((or/c false/c (listof url?)) (-> servlet? void?)) void?)
                  url->servlet/c)]{
- The first return value flushes the cache. If its optional argument is
- @racket[#f] (the default), all servlet caches are flushed. Otherwise,
- only those servlet caches to which @racket[url->path] maps the given
- URLs are flushed. The second return value is a procedure that uses
+ The first return value is a procedure that flushes the cache. If its first
+ optional argument is @racket[#f] (the default), all servlet caches are
+ flushed. Otherwise, only those servlet caches to which @racket[url->path]
+ maps the given URLs are flushed. The second optional argument is a procedure
+ which is invoked on each cached value before it is flushed, which can be used
+ to finalize servlet resources. It defaults to @racket[void].
+ 
+ The second return value is a procedure that uses
  @racket[url->path] to resolve the URL to a path, then uses
  @racket[path->servlet] to resolve that path to a servlet, caching the
  results in an internal table.
 
- @history[#:changed "6.9.0.1" "Added optional argument to first return value."]
+ @history[#:changed "6.9.0.1" "Added optional argument to first return value for list of URLs."
+	  #:changed "6.11.0.3" "Added optional argument to first return value for servlet finalizer procedure."]
 }
 
 @defproc[(make [url->servlet url->servlet/c]

--- a/web-server-lib/web-server/dispatchers/dispatch-servlets.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-servlets.rkt
@@ -23,21 +23,21 @@
  [make-cached-url->servlet
   (-> url->path/c
       path->servlet/c
-      (values (() ((or/c false/c (listof url?))) . ->* . void?)
+      (values (() ((or/c false/c (listof url?)) (-> servlet? void?)) . ->* . void?)
               url->servlet/c))])
 
 (define (make-cached-url->servlet         
          url->path 
          path->servlet)
   (define config:scripts (make-cache-table))
-  (values (lambda ([uris #f])
-            ;; This is broken - only out of date or specifically mentioned scripts should be flushed.  This destroys persistent state!
+  (values (lambda ([uris #f] [finalize void])
             (cache-table-clear!
              config:scripts
              (and uris
                   (for/list ([uri (in-list uris)])
                     (let-values ([(servlet-path _) (url->path uri)])
-                      (string->symbol (path->string servlet-path)))))))
+                      (string->symbol (path->string servlet-path)))))
+             finalize))
           (lambda (uri)
             (define-values (servlet-path _)
               (with-handlers

--- a/web-server-lib/web-server/private/cache-table.rkt
+++ b/web-server-lib/web-server/private/cache-table.rkt
@@ -8,15 +8,20 @@
   (make-cache-table (make-hasheq)
                     (make-semaphore 1)))
 
-(define (cache-table-clear! ct [entry-ids #f])
+(define (cache-table-clear! ct [entry-ids #f] [finalize void])
   (call-with-semaphore
    (cache-table-semaphore ct)
    (lambda ()
-     (if entry-ids
-       (let ([cache-hash (cache-table-hash ct)])
+     (let ([cache-hash (cache-table-hash ct)])
+       (if entry-ids
          (for ([entry-id (in-list entry-ids)])
-           (hash-remove! cache-hash entry-id))) 
-       (set-cache-table-hash! ct (make-hasheq))))))
+           (when (hash-has-key? cache-hash entry-id)
+             (finalize (hash-ref cache-hash entry-id))
+             (hash-remove! cache-hash entry-id)))
+         (begin
+           (for ([entry (in-hash-values cache-hash)])
+             (finalize entry))
+           (set-cache-table-hash! ct (make-hasheq))))))))
 
 (define (cache-table-lookup! ct entry-id entry-thunk)
   (define ht (cache-table-hash ct))
@@ -35,5 +40,5 @@
  [rename new-cache-table make-cache-table
          (-> cache-table?)]
  [cache-table-lookup! (cache-table? symbol? (-> any/c) . -> . any/c)]
- [cache-table-clear! ((cache-table?) ((or/c false/c (listof symbol?))) . ->* . void?)]
+ [cache-table-clear! ((cache-table?) ((or/c false/c (listof symbol?)) (-> any/c void?)) . ->* . void?)]
  [cache-table? (any/c . -> . boolean?)])


### PR DESCRIPTION
This PR adds an optional finalizer procedure both to the first result of `make-cached-url->servlet` and to `cache-table-clear!` in a backwards-compatible way.