### PR TITLE
make serve/servlet's #:log-file option accept an output-port? value

### DIFF
--- a/web-server-lib/web-server/servlet-env.rkt
+++ b/web-server-lib/web-server/servlet-env.rkt
@@ -66,7 +66,7 @@
                   #:mime-types-path path-string?
                   #:servlet-path string?
                   #:servlet-regexp regexp?
-                  #:log-file (or/c false/c path-string?)
+                  #:log-file (or/c false/c path-string? output-port?)
                   #:log-format (or/c log:log-format/c log:format-req/c))
                  . ->* .
                  void)])


### PR DESCRIPTION
In order to log to an output-port while keeping the "log in another thread" behavior that `dispatch-log` provides, `serve/servlet` needed to accept an `output-port?` value in the optional keyword argument `#:log-file`.

I could not find any tests lying around and I still don't understand how to run them. Feel free to give me some advice about how to write tests for this, right now I'm completely lost.