### PR TITLE
mime.types: add .mjs for JavaScript modules

### DIFF
--- a/web-server-lib/web-server/default-web-root/mime.types
+++ b/web-server-lib/web-server/default-web-root/mime.types
@@ -1437,7 +1437,7 @@ text/enriched
 text/example
 text/fwdred
 text/html					html htm
-text/javascript
+text/javascript					mjs
 text/n3						n3
 text/parityfec
 text/plain					txt text conf def list log in


### PR DESCRIPTION
Browsers are now supporting ES6 (aka ES 2015) modules,
which must be served with with a JavaScript MIME type.

However, it is not always possible to determine if a file is a module
or a traditional script based on content alone,
so it is recommended to use the extension `.mjs`,
rather than `.js`, for clarity.

This commit adds `.mjs` as an extension for `text/javascript`,
which is the MIME type specified by the WHATWG HTML standard.
("Servers should use `text/javascript` for JavaScript resources.
Servers should not use other JavaScript MIME types for JavaScript
resources, and must not use non-JavaScript MIME types."
--- https://html.spec.whatwg.org/#scriptingLanguages )

Conservatively, it does not change the MIME type for `.js`,
which is currently mapped to `application/javascript`.
An IETF proposal to reflect the WHATWG standard by deprecating
`application/javascript` in favor of `text/javascript` remains
in draft status (see
https://tools.ietf.org/html/draft-ietf-dispatch-javascript-mjs-02).