### PR TITLE
redirect-to and redirect/get: support 307 redirects

### DIFF
--- a/web-server-doc/web-server/scribblings/lang.scrbl
+++ b/web-server-doc/web-server/scribblings/lang.scrbl
@@ -47,9 +47,7 @@
  Like @racket[send/suspend/url/dispatch] but with a string URL representation.
 }
 
-@deftogether[(
-@defproc[(redirect/get) request?]
-)]{
 
+@defproc[(redirect/get [#:headers hs (listof header?) empty]) request?]{
 See @racketmodname[web-server/servlet/web].}
 }

--- a/web-server-doc/web-server/scribblings/web.scrbl
+++ b/web-server-doc/web-server/scribblings/web.scrbl
@@ -152,15 +152,19 @@ the request is returned from this call to @racket[send/suspend].
 
 @defproc[(redirect/get [#:headers hs (listof header?) empty])
          request?]{
- Calls @racket[send/suspend] with @racket[redirect-to], passing @racket[hs] as the headers.
+  Calls @racket[send/suspend] with @racket[redirect-to],
+  passing @racket[hs] as the headers and
+  @racket[see-other] as the @tech{redirection status}.
        
- This implements the Post-Redirect-Get pattern. 
- Use this to prevent the @onscreen["Refresh"] button from duplicating effects, such as adding items to a database. 
+  This implements the @tech{Post-Redirect-Get} pattern. 
+  Use this to prevent the @onscreen["Refresh"] button from duplicating effects,
+  such as adding items to a database.
 }
 
 @defproc[(redirect/get/forget [#:headers hs (listof header?) empty])
          request?]{
- Calls @racket[send/forward] with @racket[redirect-to], passing @racket[hs] as the headers.
+  Like @racket[redirect/get], but using @racket[send/forward]
+  instead of @racket[send/suspend].
 }
                   
 @defthing[current-servlet-continuation-expiration-handler 

--- a/web-server-lib/web-server/lang/web.rkt
+++ b/web-server-lib/web-server/lang/web.rkt
@@ -44,7 +44,7 @@
    [send/suspend/url ((url? . -> . can-be-response?) . -> . request?)]
    [send/suspend/url/dispatch ((((request? . -> . any/c) . -> . url?) . -> . can-be-response?)
                                . -> . any/c)]
-   [redirect/get (-> request?)])
+   [redirect/get (->* () (#:headers (listof header?)) request?)])
 
 ;; initial-servlet : (request -> response) -> (request -> can-be-response?)
 (define (initialize-servlet start)
@@ -122,5 +122,7 @@
        (read (open-input-bytes kont)))]
      [_ #f]))) 
 
-(define (redirect/get)
-  (send/suspend/url (lambda (k-url) (redirect-to (url->string k-url) temporarily))))
+(define (redirect/get #:headers [hs null])
+  (send/suspend/url
+   (lambda (k-url)
+     (redirect-to (url->string k-url) see-other #:headers hs))))

--- a/web-server-lib/web-server/servlet/web.rkt
+++ b/web-server-lib/web-server/servlet/web.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
 (require racket/contract
-         racket/list
          net/url)
 (require web-server/managers/manager
          web-server/private/util
@@ -145,8 +144,8 @@
 ;; ************************************************************
 ;; HIGHER-LEVEL EXPORTS
 
-(define ((make-redirect/get send/suspend) #:headers [hs empty])
-  (send/suspend (lambda (k-url) (redirect-to k-url temporarily #:headers hs))))
+(define ((make-redirect/get send/suspend) #:headers [hs null])
+  (send/suspend (lambda (k-url) (redirect-to k-url see-other #:headers hs))))
 
 ; redirect/get : -> request
 (define redirect/get (make-redirect/get send/suspend))


### PR DESCRIPTION
Previously, the `temporarily` status for `redirect-to`
meant the HTTP status `302 Found`, though this was
not guaranteed or documented.
For `302 Found` responses, user agents may use the same method as
the original request or may change the method from `POST` to `GET`.

This inconsistency is resolved by responding with `307 Temporary Redirect`
when the original method should always be used and
responding with `303 See Other` (which was already supported)
when the method should be changed from `POST` to `GET`,
e.g. for the Post-Redirect-Get pattern.

This commit changes the `temporarily` status for `redirect-to`
to mean `307 Temporary Redirect` and changes `redirect/get`
and `redirect/get/forget` to use the `see-other` status.

Also, the version of `redirect/get` from `#lang web-server`
is changed to accept a `#:headers` argument for consistency with
the stateful version.

This commit does not change the `permanently` status for `redirect-to`.
While `301 Moved Permanently` has the same issues as `302 Found`,
the replacement, `308 Permanent Redirect`, is not supported by
Internet Explorer on Windows 7 or 8.1
(though aparently IE on Windows 10 does support it:
see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308).
The potential fallback behavior and workarounds
(see https://tools.ietf.org/html/rfc7538#section-4)
seem out-of-scope for this change.