### PR TITLE
Fix some typos in the web-server docs

### DIFF
--- a/web-server-doc/web-server/scribblings/running.scrbl
+++ b/web-server-doc/web-server/scribblings/running.scrbl
@@ -63,12 +63,12 @@ One command-line utility is provided with the @|web-server|:
 
 @commandline{plt-web-server [-f <file-name> -p <port> -a <ip-address> --ssl]}
 
-The optional file-name argument specifies the path to a
+The optional @tt{file-name} argument specifies the path to a
 @racket[configuration-table] S-expression (see @racket[configuration-table->sexpr] for the syntax documentation.)
 If this is not provided, the
 default configuration shipped with the server is used. The optional
-port and ip-address arguments override the corresponding portions of
-the @racket[configuration-table]. If the SSL option is provided, then 
+@tt{port} and @tt{ip-address} arguments override the corresponding portions of
+the @racket[configuration-table]. If the SSL option is provided, then
 the server uses HTTPS with @filepath{server-cert.pem} and @filepath{private-key.pem}
 in the current directory, with 443 as the default port. (See the @racketmodname[openssl] 
 module for details on the SSL implementation.)

--- a/web-server-doc/web-server/scribblings/running.scrbl
+++ b/web-server-doc/web-server/scribblings/running.scrbl
@@ -68,7 +68,7 @@ The optional @tt{file-name} argument specifies the path to a
 If this is not provided, the
 default configuration shipped with the server is used. The optional
 @tt{port} and @tt{ip-address} arguments override the corresponding portions of
-the @racket[configuration-table]. If the SSL option is provided, then
+the @racket[configuration-table]. If the @tt{ssl} option is provided, then
 the server uses HTTPS with @filepath{server-cert.pem} and @filepath{private-key.pem}
 in the current directory, with 443 as the default port. (See the @racketmodname[openssl] 
 module for details on the SSL implementation.)

--- a/web-server-doc/web-server/scribblings/running.scrbl
+++ b/web-server-doc/web-server/scribblings/running.scrbl
@@ -41,7 +41,7 @@ The following API is provided to customize the server instance:
 }
 
 @defproc[(static-files-path [path path-string?]) void]{
- This instructs the Web server to serve static files, such as stylesheet and images, from @racket[path].
+ This instructs the Web server to serve static files, such as stylesheets and images, from @racket[path].
 }
 
 If you want more control over specific parameters, keep reading about @racketmodname[web-server/servlet-env].

--- a/web-server-doc/web-server/scribblings/web-server.scrbl
+++ b/web-server-doc/web-server/scribblings/web-server.scrbl
@@ -11,7 +11,7 @@ This manual describes the Racket libraries for building Web applications.
 
 @secref["servlet"] and @secref["stateless"] describe two ways to write Web applications. 
 @secref["servlet"] use the entire Racket language, but their continuations are stored in the Web server's memory.
-@secref["stateless"] use a slightly restricted Racket language, but their continuation can be stored by the Web client or on a Web server's disk. If you can, you want to use @secref["stateless"] for the improved scalability.
+@secref["stateless"] use a slightly restricted Racket language, but their continuations can be stored by the Web client or on a Web server's disk. If you can, you want to use @secref["stateless"] for the improved scalability.
 
 The @secref["http"] section describes the common library functions for manipulating HTTP requests and creating HTTP responses.
 In particular, this section covers cookies, authentication, and request bindings.


### PR DESCRIPTION
I spotted a handful of problems in the web-server docs:

* typos
* parallelism problems
* words that probably ought to be typed out (@tt) because they're referring to formal parameters of a function or command-line invocation