### PR TITLE
strengthen contracts on `response-code` and `response-seconds`

### DIFF
--- a/web-server-doc/web-server/scribblings/cache-table.scrbl
+++ b/web-server-doc/web-server/scribblings/cache-table.scrbl
@@ -30,8 +30,10 @@ functions.
  Otherwise, clears only the entries with keys in @racket[entry-ids].
  The procedure @racket[finalize] is invoked on each entry before it is cleared.
 
- @history[#:changed "6.9.0.1" "Added optional argument for list of entry keys."
-          #:changed "6.11.0.3" "Added optional argument for finalizer procedure."]
+ @history[#:changed "1.3"
+          "Added optional argument for list of entry keys."
+          #:changed "1.3"
+          "Added optional argument for finalizer procedure."]
 }
 
 @defproc[(cache-table? [v any/c])

--- a/web-server-doc/web-server/scribblings/dispatch-servlets.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatch-servlets.scrbl
@@ -35,8 +35,8 @@
  @racket[path->servlet] to resolve that path to a servlet, caching the
  results in an internal table.
 
- @history[#:changed "6.9.0.1" "Added optional argument to first return value for list of URLs."
-	  #:changed "6.11.0.3" "Added optional argument to first return value for servlet finalizer procedure."]
+ @history[#:changed "1.3" "Added optional argument to first return value for list of URLs."
+	  #:changed "1.3" "Added optional argument to first return value for servlet finalizer procedure."]
 }
 
 @defproc[(make [url->servlet url->servlet/c]

--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -31,6 +31,9 @@ This module provides a few functions for dispatchers in general.
 
 @defthing[dispatcher/c contract?]{
  Equivalent to @racket[(connection? request? . -> . any)].
+
+  @history[#:changed "1.3"
+           @elem{Weakened the range contract to allow @racket[any]}]
 }
 
 @defproc[(dispatcher-interface-version/c (any any/c)) boolean?]{
@@ -244,6 +247,9 @@ a URL that refreshes the password file, servlet cache, etc.}
  Logs requests to @racket[log-path], which can be either a filepath or an @racket[output-port?],
  using @racket[format] to format the requests.
  Then invokes @racket[next-dispatcher].
+
+ @history[#:changed "1.3"
+          @elem{Allow @racket[log-path] to be an @racket[output-port?]}]
 }}
 
 @; ------------------------------------------------------------

--- a/web-server-doc/web-server/scribblings/formlets.scrbl
+++ b/web-server-doc/web-server/scribblings/formlets.scrbl
@@ -216,12 +216,18 @@ types. Refer to @secref["input-formlets"] for example low-level formlets using t
 
  (Actually, @racket[formlet/c] is a macro which avoids using @racket[dynamic->*]
  when the number of range contracts for the processing function is known at compile time.)
+
+ @history[#:changed "1.3"
+          "Fixed support for multiple return values."]
 }
 
 @defthing[formlet*/c contract?]{
   Similar to the contracts created by @racket[formlet/c], but uses @racket[any]
   to avoid checking the results (or even specifying the number of results)
   of the processing function.
+
+  @history[#:changed "1.3"
+          "Fixed support for multiple return values."]
 }
 
 @defproc[(pure [value any/c]) (formlet/c any/c)]{
@@ -505,6 +511,11 @@ a list of elements of the sequence.
 
 @defthing[input-int (formlet/c number?)]{
   Equivalent to @racket[(to-number input-string)].
+  Note that, despite the name, the result
+  @bold{is not guaranteed to be an integer.}
+  
+  @history[#:changed "1.3"
+           "Weakened result contract to allow any number."]
 }
 
 @defthing[input-symbol (formlet/c symbol?)]{
@@ -607,3 +618,10 @@ library @racketmodname[web-server/formlets/unsafe] provides the same API as
  contracts.} As the name implies, using @racketmodname[web-server/formlets/unsafe]
 may produce inscrutable error messages and other unpleasant effects of programming
 without contracts: you have been warned.
+
+@history[#:changed "1.3"
+         @elem{Added @racketmodname[web-server/formlets/stateless] and
+          @racketmodname[web-server/formlets/unsafe] and
+          changed combinators from @racketmodname[web-server/formlets]
+          to produce serializable formlets.}]   
+          

--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -169,13 +169,16 @@ Here is an example typical of what you will find in many applications:
 
 @defmodule[web-server/http/response-structs]{
 
-@defstruct*[response
-           ([code number?]
-            [message bytes?]
-            [seconds number?]
-            [mime (or/c false/c bytes?)]
-            [headers (listof header?)]
-            [output (output-port? . -> . any)])]{
+@deftogether[
+ (@defstruct*[response
+              ([code response-code/c]
+               [message bytes?]
+               [seconds real?]
+               [mime (or/c #f bytes?)]
+               [headers (listof header?)]
+               [output (output-port? . -> . any)])]
+   @defthing[response-code/c flat-contract?
+             #:value (integer-in 100 999)])]{
 
 An HTTP response where @racket[output] produces the body by writing to
 the output port. @racket[code] is the response code, @racket[message]
@@ -223,12 +226,18 @@ Examples:
    void)
  ]
 
-@history[#:changed "1.2"
+@history[#:changed "1.3"
+         @elem{Added @racket[response-code/c] and made the
+            contracts on @racket[code] and @racket[seconds]
+            stronger (rather than accepting @racket[number?].}
+         #:changed "1.2"
          @elem{Contract on @racket[output] weaked to allow @racket[any]
                as the result (instead of demanding @racket[void?]).}]
 }
 
-@defproc[(response/full [code number?] [message bytes?] [seconds number?] [mime (or/c false/c bytes?)]
+@defproc[(response/full [code response-code/c] [message bytes?]
+                        [seconds real?]
+                        [mime (or/c #f bytes?)]
                         [headers (listof header?)] [body (listof bytes?)])
          response?]{
  A constructor for responses where @racket[body] is the response body.
@@ -246,6 +255,10 @@ Examples:
          #"\">here</a> instead."
          #"</p></body></html>"))
  ]
+
+ @history[#:changed "1.3"
+          @elem{Updated contracts on @racket[code] and @racket[seconds]
+             as with @racket[response].}]
 }
                    
 @defproc[(response/output [output (-> output-port? any)]
@@ -258,7 +271,10 @@ Examples:
 Equivalent to
 @racketblock[(response code message seconds mime-type headers output)]
 
-@history[#:changed "1.2"
+@history[#:changed "1.3"
+         @elem{Updated contracts on @racket[code] and @racket[seconds]
+            as with @racket[response].}
+         #:changed "1.2"
          @elem{Contract on @racket[output] weaked to allow @racket[any]
                as the result (instead of demanding @racket[void?]).}]
 }
@@ -766,10 +782,10 @@ web-server/insta
 @declare-exporting[web-server/http/xexpr web-server]
 
 @defproc[(response/xexpr [xexpr xexpr/c]
-                         [#:code code number? 200]
+                         [#:code code response-code/c 200]
                          [#:message message bytes? #"Okay"]
-                         [#:seconds seconds number? (current-seconds)]
-                         [#:mime-type mime-type (or/c false/c bytes?) TEXT/HTML-MIME-TYPE]
+                         [#:seconds seconds real? (current-seconds)]
+                         [#:mime-type mime-type (or/c #f bytes?) TEXT/HTML-MIME-TYPE]
                          [#:headers headers (listof header?) empty]
                          [#:cookies cookies (listof cookie?) empty]
                          [#:preamble preamble bytes? #""])
@@ -783,4 +799,8 @@ web-server/insta
  ]
 
  This is a viable function to pass to @racket[set-any->response!].
- }
+
+@history[#:changed "1.3"
+          @elem{Updated contracts on @racket[code] and @racket[seconds]
+             as with @racket[response].}]
+}

--- a/web-server-doc/web-server/scribblings/lang.scrbl
+++ b/web-server-doc/web-server/scribblings/lang.scrbl
@@ -49,5 +49,10 @@
 
 
 @defproc[(redirect/get [#:headers hs (listof header?) empty]) request?]{
-See @racketmodname[web-server/servlet/web].}
+See @racketmodname[web-server/servlet/web].
+
+  @history[#:changed "1.3"
+           @elem{Added @racket[hs] argument and
+              changed to use @racket[see-other] instead of @racket[temporarily].}]
+ }
 }

--- a/web-server-doc/web-server/scribblings/servlet-env.scrbl
+++ b/web-server-doc/web-server/scribblings/servlet-env.scrbl
@@ -240,4 +240,7 @@ order they appear in the list.
  
  If @racket[connection-close?] is @racket[#t], then every connection is closed after one
  request. Otherwise, the client decides based on what HTTP version it uses.
+
+ @history[#:changed "1.3"
+          @elem{Added support for providing @racket[log-file] as an output port.}]
 }

--- a/web-server-doc/web-server/scribblings/templates.scrbl
+++ b/web-server-doc/web-server/scribblings/templates.scrbl
@@ -163,7 +163,9 @@ title line of different calls to @racket[fast-template]:
 }
 ]
 
-@section{Gotchas: @"@" Syntax: @"@" character, identifiers, and spaces}
+@section{Gotchas:}
+@subsection[#:tag "Gotchas____Syntax____character__identifiers__and_spaces"]{
+ @"@" Syntax: @"@" character, identifiers, and spaces}
 
 To obtain an @litchar["@"] character in template output, you must
 escape the it, because it is the escape character of the
@@ -199,7 +201,7 @@ is. The safest thing to do is explicitly delimit the identifier with @"|"s:
 If you intend to use templates a lot, you should familiarize yourself
 with the details of the @|at-reader-ref|.
 
-@section{Gotchas: Iteration}
+@subsection[#:tag "Gotchas__Iteration"]{Iteration}
 
 Since the template is compiled into a Racket program, only its results
 will be printed. For example, suppose we have the template:
@@ -267,7 +269,7 @@ issue for you called @racket[in]:
 }|
 Notice how it also avoids the absurd amount of punctuation on line two.
 
-@section{Escaping}
+@subsection{Escaping}
 
 @margin-note{Thanks to Michael W. for this section.}
 
@@ -381,7 +383,10 @@ valid XML.
 
 @defform*[((include-template/xml path-spec)
            (include-template/xml #:command-char command-char path-spec))]{
- Like @racket[include/template], but expands to a @racket[cdata] structure.}
+ Like @racket[include/template], but expands to a @racket[cdata] structure.
+
+@history[#:added "1.3"]
+}
 
 @defform[(in x xs e ...)]{
  Expands into

--- a/web-server-doc/web-server/scribblings/web.scrbl
+++ b/web-server-doc/web-server/scribblings/web.scrbl
@@ -159,12 +159,19 @@ the request is returned from this call to @racket[send/suspend].
   This implements the @tech{Post-Redirect-Get} pattern. 
   Use this to prevent the @onscreen["Refresh"] button from duplicating effects,
   such as adding items to a database.
+
+  @history[#:changed "1.3"
+           @elem{Use @racket[see-other] instead of @racket[temporarily].}]
 }
 
 @defproc[(redirect/get/forget [#:headers hs (listof header?) empty])
          request?]{
   Like @racket[redirect/get], but using @racket[send/forward]
   instead of @racket[send/suspend].
+
+  @history[#:changed "1.3"
+           @elem{Use @racket[see-other] instead of @racket[temporarily],
+              as with @racket[redirect/get].}]
 }
                   
 @defthing[current-servlet-continuation-expiration-handler 

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -15,4 +15,4 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.2")
+(define version "1.3")

--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -28,20 +28,23 @@
   (response code message seconds mime-type headers
             output))
 
+(define/final-prop response-code/c
+  (integer-in 100 999))
 
+(provide response-code/c)
 (provide/contract
  [struct response
-         ([code number?]
+         ([code response-code/c]
           [message bytes?]
-          [seconds number?]
-          [mime (or/c false/c bytes?)]
+          [seconds real?]
+          [mime (or/c #f bytes?)]
           [headers (listof header?)]
           [output (output-port? . -> . any)])]
- [response/full (-> number? bytes? number? (or/c false/c bytes?) (listof header?) (listof bytes?) response?)]
+ [response/full (-> response-code/c bytes? real? (or/c #f bytes?) (listof header?) (listof bytes?) response?)]
  [response/output (->* ((-> output-port? any))
-                       (#:code number?
+                       (#:code response-code/c
                         #:message bytes?
-                        #:seconds number?
+                        #:seconds real?
                         #:mime-type (or/c bytes? #f)
                         #:headers (listof header?))
                        response?)]

--- a/web-server-lib/web-server/http/xexpr.rkt
+++ b/web-server-lib/web-server/http/xexpr.rkt
@@ -29,5 +29,5 @@
 (provide/contract
  [response/xexpr 
   ((pretty-xexpr/c)
-   (#:code number? #:message bytes? #:seconds number? #:mime-type (or/c false/c bytes?) #:cookies (listof cookie?) #:headers (listof header?) #:preamble bytes?)
+   (#:code response-code/c #:message bytes? #:seconds real? #:mime-type (or/c #f bytes?) #:cookies (listof cookie?) #:headers (listof header?) #:preamble bytes?)
    . ->* . response?)])


### PR DESCRIPTION
Previously, both accepted `number?`, which was too permissive.

This commit adds `response-code/c`, which is defined as
`(integer-in 100 999)` per [RFC 2616 §6.1.1][1] ("The Status-Code
element is a 3-digit integer ...").

The contract for `response-seconds` is `real?`, which is the
range of `seconds->date` (which is used internally to generate the
`Last-Modified` header).

[1]: https://tools.ietf.org/html/rfc2616#section-6.1.1