### PR TITLE
Offer a variety of default standard status HTTP response messages

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -228,7 +228,7 @@ Examples:
                as the result (instead of demanding @racket[void?]).}]
 }
 
-@defproc[(response/full [code number?] [message bytes?] [seconds number?] [mime (or/c false/c bytes?)]
+@defproc[(response/full [code number?] [message (or/c false/c bytes?] [seconds number?] [mime (or/c false/c bytes?)]
                         [headers (listof header?)] [body (listof bytes?)])
          response?]{
  A constructor for responses where @racket[body] is the response body.
@@ -246,21 +246,72 @@ Examples:
          #"\">here</a> instead."
          #"</p></body></html>"))
  ]
+
+ If @racket[message] is not supplied or is @racket[#f], a status message will be inferred based on @racket[code]. Status messages will be inferred based on RFCs 7231 (``Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content'') and 7235 (``Hypertext Transfer Protocol (HTTP/1.1): Authentication''). These are the following:
+
+  @tabular[#:sep @hspace[1]
+   (list (list @bold{Code} @bold{Message})
+   (list 100 "Continue")
+   (list 101 "Switching Protocols")
+
+   (list 200 "OK")
+   (list 201 "Created")
+   (list 202 "Accepted")
+   (list 203 "Non-Authoritative Information")
+   (list 204 "No Content")
+   (list 205 "Reset Content")
+
+   (list 300 "Multiple Choices")
+   (list 301 "Moved Permanently")
+   (list 302 "Found")
+   (list 303 "See Other")
+   (list 305 "Use Proxy")
+   (list 307 "Temporary Redirect")
+
+   (list 400 "Bad Request")
+   (list 401 "Unauthorized")
+   (list 402 "Payment Required")
+   (list 403 "Forbidden")
+   (list 404 "Not Found")
+   (list 405 "Method Not Allowed")
+   (list 406 "Not Acceptable")
+   (list 407 "Proxy Authentication Required")
+   (list 408 "Request Timeout")
+   (list 409 "Conflict")
+   (list 410 "Gone")
+   (list 411 "Length Required")
+   (list 413 "Payload Too Large")
+   (list 414 "URI Too Long")
+   (list 415 "Unsupported Media Type")
+   (list 417 "Expectation Failed")
+   (list 426 "Upgrade Required")
+
+   (list 500 "Internal Server Error")
+   (list 501 "Not Implemented")
+   (list 502 "Bad Gateway")
+   (list 503 "Service Unavailable")
+   (list 504 "Gateway Timeout")
+   (list 505 "HTTP Version Not Supported"))]
+
+@history[#:changed "1.3"
+         @elem{Contract on @racket[message] relaxed to allow both @racket[#f] and a @racket[bytes?], with a default of @racket[#f]. Previously, @racket[bytes?] was required, and had a deault of @racket[#"Okay"].}]
 }
-                   
+
 @defproc[(response/output [output (-> output-port? any)]
                           [#:code code number? 200]
-                          [#:message message bytes? #"Okay"]
+                          [#:message message (or/c false/c bytes?) #f]
                           [#:seconds seconds number? (current-seconds)]
                           [#:mime-type mime-type (or/c bytes? #f) TEXT/HTML-MIME-TYPE]
                           [#:headers headers (listof header?) '()])
          response?]{
 Equivalent to
-@racketblock[(response code message seconds mime-type headers output)]
+@racketblock[(response code message seconds mime-type headers output)], with the understanding that if @racket[message] is missing, it will be inferred from @racket[code] using the association between status codes and messages found in RFCs 7231 and 7235. See the documentation for @racketlink[response/full] for the table of built-in status codes.
 
 @history[#:changed "1.2"
-         @elem{Contract on @racket[output] weaked to allow @racket[any]
+         @elem{Contract on @racket[output] weakened to allow @racket[any]
                as the result (instead of demanding @racket[void?]).}]
+@history[#:changed "1.3"
+         @elem{Contract on @racket[message] relaxed to allow both @racket[#f] and a @racket[bytes?], with a default of @racket[#f]. Previously, @racket[bytes?] was required, and had a deault of @racket[#"Okay"].}]
 }
 
 @defthing[TEXT/HTML-MIME-TYPE bytes?]{Equivalent to @racket[#"text/html; charset=utf-8"].}
@@ -767,7 +818,7 @@ web-server/insta
 
 @defproc[(response/xexpr [xexpr xexpr/c]
                          [#:code code number? 200]
-                         [#:message message bytes? #"Okay"]
+                         [#:message message (or/c false/c bytes?) #f]
                          [#:seconds seconds number? (current-seconds)]
                          [#:mime-type mime-type (or/c false/c bytes?) TEXT/HTML-MIME-TYPE]
                          [#:headers headers (listof header?) empty]
@@ -783,4 +834,9 @@ web-server/insta
  ]
 
  This is a viable function to pass to @racket[set-any->response!].
+
+ See the documentation for @racketlink[response/full] to see how @racket[#f] is handled for @racket[message].
+
+@history[#:changed "1.3"
+         @elem{Contract on @racket[message] relaxed to allow both @racket[#f] and @racket[bytes?], with a default of @racket[#f]. Previously, @racket[bytes?] was required, and had a deault of @racket[#"Okay"].}]
  }

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -15,4 +15,4 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.2")
+(define version "1.3")

--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -1,14 +1,22 @@
 #lang racket/base
-(require racket/contract 
-         web-server/http/request-structs)
+(require racket/contract
+         racket/match
+         web-server/http/request-structs
+         "status-code.rkt")
+
+(module+ test
+  (require rackunit))
 
 (define TEXT/HTML-MIME-TYPE #"text/html; charset=utf-8")
 
 (struct response (code message seconds mime headers output))
 
 (define (response/full code message seconds mime headers body)
-  (response code message seconds mime
-            (list* (make-header #"Content-Length" 
+  (response code
+            (infer-response-message code message)
+            seconds
+            mime
+            (list* (make-header #"Content-Length"
                                 (string->bytes/utf-8
                                  (number->string
                                   (for/fold ([len 0])
@@ -21,13 +29,49 @@
 
 (define (response/output output
                          #:code [code 200]
-                         #:message [message #"Okay"]
+                         #:message [message #f]
                          #:seconds [seconds (current-seconds)]
                          #:mime-type [mime-type TEXT/HTML-MIME-TYPE]
                          #:headers [headers '()])
-  (response code message seconds mime-type headers
+  (response code
+            (infer-response-message code message)
+            seconds
+            mime-type
+            headers
             output))
 
+(module+ test
+  (let ([output (lambda (op) void)])
+    ;; check message as bytes
+    (let [(resp (response/output output
+                                 #:code 123
+                                 #:message #"bites!"))]
+      (check-equal? (response-code resp) 123)
+      (check-equal? (response-message resp) #"bites!"))
+    ;; check message as #f
+    (let [(resp (response/output output
+                                 #:code 200
+                                 #:message #f))]
+      (check-equal? (response-code resp) 200)
+      (check-equal? (response-message resp) #"OK"))
+    ;; check message not supplied, but code supplied
+    (let [(resp (response/output output
+                                 #:code 200))]
+      (check-equal? (response-code resp) 200)
+      (check-equal? (response-message resp) #"OK"))
+    ;; check code not supplied, message supplied
+    (let [(resp (response/output output
+                                 #:message #"bite this"))]
+      (check-equal? (response-code resp) 200)
+      (check-equal? (response-message resp) #"bite this"))
+    ;; check neither message nor code supplied
+    (let [(resp (response/output output))]
+      (check-equal? (response-code resp) 200)
+      (check-equal? (response-message resp) #"OK"))
+    ;; check non-standard status code
+    (let [(resp (response/output output #:code 123))]
+      (check-equal? (response-code resp) 123)
+      (check-equal? (response-message resp) #"OK"))))
 
 (provide/contract
  [struct response
@@ -37,10 +81,10 @@
           [mime (or/c false/c bytes?)]
           [headers (listof header?)]
           [output (output-port? . -> . any)])]
- [response/full (-> number? bytes? number? (or/c false/c bytes?) (listof header?) (listof bytes?) response?)]
+ [response/full (-> number? (or/c false/c bytes?) number? (or/c false/c bytes?) (listof header?) (listof bytes?) response?)]
  [response/output (->* ((-> output-port? any))
                        (#:code number?
-                        #:message bytes?
+                        #:message (or/c false/c bytes?)
                         #:seconds number?
                         #:mime-type (or/c bytes? #f)
                         #:headers (listof header?))

--- a/web-server-lib/web-server/http/status-code.rkt
+++ b/web-server-lib/web-server/http/status-code.rkt
@@ -1,0 +1,96 @@
+#lang racket/base
+
+(require racket/contract
+         racket/match
+         (only-in racket/string
+                  non-empty-string?))
+
+(provide/contract
+ [message-for-status-code
+  (number? . -> . (or/c false/c non-empty-string?))]
+ [DEFAULT-STATUS-MESSAGE
+  bytes?]
+ [infer-response-message
+  (number? (or/c false/c bytes?) . -> . bytes?)])
+
+(module+ test
+  (require rackunit))
+
+;; HTTP status codes coming from
+;;
+;; + Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content
+;;   (https://tools.ietf.org/html/rfc7231)
+;;
+;; + Hypertext Transfer Protocol (HTTP/1.1): Authentication
+;;   (https://tools.ietf.org/html/rfc7235)
+
+(define/contract common-http-status-codes&messages
+  (and/c (hash/c (integer-in 100 599) non-empty-string?)
+         immutable?)
+  (hasheq
+   100 "Continue"
+   101 "Switching Protocols"
+
+   200 "OK"
+   201 "Created"
+   202 "Accepted"
+   203 "Non-Authoritative Information"
+   204 "No Content"
+   205 "Reset Content"
+
+   300 "Multiple Choices"
+   301 "Moved Permanently"
+   302 "Found"
+   303 "See Other"
+   305 "Use Proxy"
+   307 "Temporary Redirect"
+
+   400 "Bad Request"
+   401 "Unauthorized"
+   402 "Payment Required"
+   403 "Forbidden"
+   404 "Not Found"
+   405 "Method Not Allowed"
+   406 "Not Acceptable"
+   407 "Proxy Authentication Required"
+   408 "Request Timeout"
+   409 "Conflict"
+   410 "Gone"
+   411 "Length Required"
+   413 "Payload Too Large"
+   414 "URI Too Long"
+   415 "Unsupported Media Type"
+   417 "Expectation Failed"
+   426 "Upgrade Required"
+
+   500 "Internal Server Error"
+   501 "Not Implemented"
+   502 "Bad Gateway"
+   503 "Service Unavailable"
+   504 "Gateway Timeout"
+   505 "HTTP Version Not Supported"))
+
+(module+ test
+  (check-equal?
+   (list 100 101
+         200 201 202 203 204 205
+         300 301 302 303 305 307
+         400 401 402 403 404 405 406 407 408 409 410 411 413 414 415 417 426
+         500 501 502 503 504 505)
+   (sort (hash-keys common-http-status-codes&messages) <)))
+
+(define (message-for-status-code code)
+  (hash-ref common-http-status-codes&messages code #f))
+
+(define DEFAULT-STATUS-MESSAGE #"OK")
+
+(define (infer-response-message code message)
+  (match message
+    [(? bytes?)
+     message]
+    [else
+     (match (message-for-status-code code)
+       [(? string? s)
+        (string->bytes/utf-8 s)]
+       [else
+        DEFAULT-STATUS-MESSAGE])]))

--- a/web-server-lib/web-server/http/xexpr.rkt
+++ b/web-server-lib/web-server/http/xexpr.rkt
@@ -1,33 +1,70 @@
 #lang racket/base
 (require racket/contract
          racket/list
+         racket/match
          xml
          web-server/private/xexpr
          (except-in net/cookies/server
                     make-cookie)
          "request-structs.rkt"
          "cookie.rkt"
-         "response-structs.rkt")
+         "response-structs.rkt"
+         "status-code.rkt")
+
+(module+ test
+  (require rackunit))
 
 (define (response/xexpr
          xexpr
-         #:code [code 200] 
-         #:message [message #"Okay"]
+         #:code [code 200]
+         #:message [message #f]
          #:seconds [seconds (current-seconds)]
          #:mime-type [mime-type TEXT/HTML-MIME-TYPE]
          #:cookies [cooks empty]
          #:headers [hdrs empty]
          #:preamble [preamble #""])
   (response
-   code message seconds mime-type 
+   code (infer-response-message code message) seconds mime-type
    ; rfc2109 also recommends some cache-control stuff here for cookies
    (append hdrs (map cookie->header cooks))
    (λ (out)
      (write-bytes preamble out)
      (write-xexpr xexpr out))))
 
+(module+ test
+  ;; sanity check: we get a response
+  (check-true (response? (response/xexpr '(foo))))
+  (let ([resp (response/xexpr '(html))])
+    ;; no code, no message ==> 200 "OK"
+    (check-equal? 200 (response-code resp))
+    (check-equal? #"OK" (response-message resp)))
+  ;; code present, message absent
+  (let ([resp (response/xexpr '(html) #:code 201)])
+    (check-equal? 201 (response-code resp))
+    (check-equal? #"Created" (response-message resp)))
+  ;; unknown status code used, no message
+  (let ([resp (response/xexpr '(html) #:code 256)])
+    (check-equal? 256 (response-code resp))
+    (check-equal? #"OK" (response-message resp)))
+  ;; known code used, #f used as message
+  (let ([resp (response/xexpr '(html) #:code 204 #:message #f)])
+    (check-equal? 204 (response-code resp))
+    (check-equal? #"No Content" (response-message resp)))
+  ;; known code used, message lookup overridden
+  (let ([resp (response/xexpr '(html) #:code 204 #:message #"Cowabunga")])
+    (check-equal? 204 (response-code resp))
+    (check-equal? #"Cowabunga" (response-message resp)))
+  ;; code absent, message #f ==> 200 "OK"
+  (let ([resp (response/xexpr '(html) #:message #f)])
+    (check-equal? 200 (response-code resp))
+    (check-equal? #"OK" (response-message resp)))
+  ;; code absent, message present ==> 200 <message>
+  (let ([resp (response/xexpr '(html) #:message #"Say Cheese")])
+    (check-equal? 200 (response-code resp))
+    (check-equal? #"Say Cheese" (response-message resp))))
+
 (provide/contract
- [response/xexpr 
+ [response/xexpr
   ((pretty-xexpr/c)
-   (#:code number? #:message bytes? #:seconds number? #:mime-type (or/c false/c bytes?) #:cookies (listof cookie?) #:headers (listof header?) #:preamble bytes?)
+   (#:code number? #:message (or/c false/c bytes?) #:seconds number? #:mime-type (or/c false/c bytes?) #:cookies (listof cookie?) #:headers (listof header?) #:preamble bytes?)
    . ->* . response?)])


### PR DESCRIPTION
The various HTTP response-generating functions (`response/output`, `response/full`, and `response/xexpr`) currently require one to provide a status message, with `#"Okay"` serving as a default.

Supplying a status message in each call to `response/output` & friends is often inconvenient because, if one sticks to standard status codes, the status messages are usually a function of the code. In this pull request, I allow one to pass `#f` as the message. A message will be inferred from the code (which is required), with `#"OK"` serving as a fallback.

Existing code does not break. This change makes things more convenient going forward because one can omit one keyword argument in most cases. As before, it is always possible to supply a status message; if supplied, it will be used (the table of standard status messages will not be consulted).

The status codes and associated messages are taken from [RFC 7231](https://tools.ietf.org/html/rfc7231) and [RFC 7235](https://tools.ietf.org/html/rfc7235).

Additionally, there are some whitespace changes here (trimming up-to-end-of-line spaces).