### PR TITLE
Add new JSON convenience function à la response/xexpr

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -926,3 +926,37 @@ web-server/insta
           @elem{Updated contracts on @racket[code] and @racket[seconds]
              as with @racket[response].}]
 }
+
+@section[#:tag "json"]{JSON Support}
+@(require (for-label web-server/http/json
+                     json))
+
+@defmodule*/no-declare[(web-server/http/json)]{}
+
+@declare-exporting[web-server/http/json json]
+
+JSON is a widely used data format for the web. Racket's JSON
+library meets the web server with @racket[response/jsexpr],
+which is for JSON what @racket[response/xexpr] is for XML.
+
+@defproc[(response/jsexpr [jsexpr jsexpr?]
+                          [#:code code response-code/c 200]
+                          [#:message message (or/c #f bytes?) #f]
+                          [#:seconds seconds real? (current-seconds)]
+                          [#:mime-type mime-type (or/c #f bytes?) APPLICATION/JSON-MIME-TYPE]
+                          [#:headers headers (listof header?) empty]
+                          [#:cookies cookies (listof cookie?) empty])
+         response?]{
+ Equivalent to
+ @racketblock[
+ (response/full
+  code message seconds mime-type
+  (append headers (map cookie->header cookies))
+  (list (jsexpr->bytes jsexpr)))
+ ]
+
+ See the documentation for @racket[response/full] to see how @racket[message], if @racket[#f], is turned into a @racket[bytes?].
+
+@history[#:changed "1.5"
+         @elem{Added @racket[response/jsexpr].}
+}

--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -347,6 +347,8 @@ Equivalent to
 
 @defthing[TEXT/HTML-MIME-TYPE bytes?]{Equivalent to @racket[#"text/html; charset=utf-8"].}
 
+@defthing[APPLICATION/JSON-MIME-TYPE bytes?]{Equivalent to @racket[#"application/json; charset=utf-8"].}
+
 @warning{If you include a Content-Length header in a response that is inaccurate, there @bold{will be an error} in
 transmission that the server @bold{will not catch}.}
 

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -15,4 +15,4 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.4")
+(define version "1.5")

--- a/web-server-lib/web-server/http.rkt
+++ b/web-server-lib/web-server/http.rkt
@@ -6,7 +6,8 @@
          web-server/http/cookie
          web-server/http/cookie-parse
          web-server/http/redirect
-         web-server/http/xexpr)
+         web-server/http/xexpr
+         web-server/http/json)
 (provide (all-from-out web-server/http/basic-auth
                        web-server/http/digest-auth
                        web-server/http/request-structs
@@ -14,4 +15,5 @@
                        web-server/http/cookie
                        web-server/http/cookie-parse
                        web-server/http/redirect
-                       web-server/http/xexpr))
+                       web-server/http/xexpr
+                       web-server/http/json))

--- a/web-server-lib/web-server/http/json.rkt
+++ b/web-server-lib/web-server/http/json.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+(require racket/list
+         racket/contract
+         json
+         (except-in net/cookies/server
+                    make-cookie)
+         (file "request-structs.rkt")
+         (file "response-structs.rkt")
+         (file "cookie.rkt")
+         (file "status-code.rkt"))
+
+(module+ test
+  (require rackunit))
+
+(define (response/jsexpr
+         jsexpr
+         #:code [code 200]
+         #:message [message #f]
+         #:seconds [seconds (current-seconds)]
+         #:mime-type [mime-type APPLICATION/JSON-MIME-TYPE]
+         #:cookies [cooks empty]
+         #:headers [hdrs empty])
+  (response
+   code (infer-response-message code message) seconds mime-type
+   ; rfc2109 also recommends some cache-control stuff here for cookies
+   (append hdrs (map cookie->header cooks))
+   (λ (out)
+     (write-json jsexpr out))))
+
+(provide/contract
+ [response/jsexpr
+  ((jsexpr?)
+   (#:code response-code/c
+    #:message (or/c #f bytes?)
+    #:seconds real?
+    #:mime-type (or/c #f bytes?)
+    #:cookies (listof cookie?)
+    #:headers (listof header?))
+   . ->* . response?)])

--- a/web-server-lib/web-server/http/json.rkt
+++ b/web-server-lib/web-server/http/json.rkt
@@ -21,12 +21,13 @@
          #:mime-type [mime-type APPLICATION/JSON-MIME-TYPE]
          #:cookies [cooks empty]
          #:headers [hdrs empty])
+  (define js-null (json-null))
   (response
    code (infer-response-message code message) seconds mime-type
    ; rfc2109 also recommends some cache-control stuff here for cookies
    (append hdrs (map cookie->header cooks))
    (λ (out)
-     (write-json jsexpr out))))
+     (write-json jsexpr out #:null js-null))))
 
 (provide/contract
  [response/jsexpr

--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -95,4 +95,5 @@
                         #:mime-type (or/c bytes? #f)
                         #:headers (listof header?))
                        response?)]
- [TEXT/HTML-MIME-TYPE bytes?])
+ [TEXT/HTML-MIME-TYPE bytes?]
+ [APPLICATION/JSON-MIME-TYPE bytes?])

--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -9,6 +9,8 @@
 
 (define TEXT/HTML-MIME-TYPE #"text/html; charset=utf-8")
 
+(define APPLICATION/JSON-MIME-TYPE #"application/json; charset=utf-8")
+
 (struct response (code message seconds mime headers output))
 
 (define (response/full code message seconds mime headers body)

--- a/web-server-test/tests/web-server/http/json.rkt
+++ b/web-server-test/tests/web-server/http/json.rkt
@@ -42,7 +42,7 @@
                                      #:message #"Strange request"))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 Strange request\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\nfalse")
+  #"HTTP/1.1 200 Strange request\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\nfalse")
 
  (map
   (λ (b) (regexp-replace
@@ -54,7 +54,7 @@
                   #f))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: Wed, 31 Dec 1969 23:00:00 GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n[\"whoop\",{\"there\":[\"it\",\"is\"]")
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: Thu, 01 Jan 1970 00:00:00 GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\nConnection: close\r\n\r\n[\"whoop\",{\"there\":[\"it\",\"is\"]}]")
 
  ; The default MIME type ("application/json; charset=utf-8")
  ; can be overridden:
@@ -69,4 +69,4 @@
                                      #:headers (list (header #"head" #"bang"))))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nhead: bang\r\n\r\ntrue"))
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\nhead: bang\r\n\r\ntrue"))

--- a/web-server-test/tests/web-server/http/json.rkt
+++ b/web-server-test/tests/web-server/http/json.rkt
@@ -5,6 +5,7 @@
          web-server/private/connection-manager
          web-server/http/response
          web-server/http
+         json
          "../util.rkt"
          (file "util.rkt"))
 
@@ -14,26 +15,26 @@
  (write-response tm (response/jsexpr '("booga")))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\n[\"booga\"")
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\n[\"booga\"]")
 
  ; Showing off all default headers and other values (200, "OK"):
  (write-response tm (response/jsexpr (hasheq 'jay "zee")))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n{\"jay\":\"zee\"}")
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\n{\"jay\":\"zee\"}")
 
  ; We respect the json-null parameter:
  (write-response tm (parameterize ([json-null 'jibby-jab])
                       (response/jsexpr 'jibby-jab)))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\nnull")
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\nnull")
 
  (write-response tm (response/jsexpr "jazzy jazz"
                                      #:code 404))
  =>
  (bytes-sort
-  #"HTTP/1.1 404 Not Found\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n\"jazzy jazz\"")
+  #"HTTP/1.1 404 Not Found\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\n\"jazzy jazz\"")
 
  ; The message is normally inferred from the status code,
  ; but you can use whatever you want:

--- a/web-server-test/tests/web-server/http/json.rkt
+++ b/web-server-test/tests/web-server/http/json.rkt
@@ -11,34 +11,34 @@
 (define tm (start-timer-manager))
 
 (test
- (write-response (response/jsexpr '("booga")))
+ (write-response tm (response/jsexpr '("booga")))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\n[\"booga\"")
 
  ; Showing off all default headers and other values (200, "OK"):
- (write-response (response/jsexpr (hasheq 'jay "zee")))
+ (write-response tm (response/jsexpr (hasheq 'jay "zee")))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n{\"jay\":\"zee\"}")
 
  ; We respect the json-null parameter:
- (write-response (parameterize ([json-null 'jibby-jab])
-                   (response/jsexpr 'jibby-jab)))
+ (write-response tm (parameterize ([json-null 'jibby-jab])
+                      (response/jsexpr 'jibby-jab)))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\nnull")
 
- (write-response (response/jsexpr "jazzy jazz"
-                                  #:code 404))
+ (write-response tm (response/jsexpr "jazzy jazz"
+                                     #:code 404))
  =>
  (bytes-sort
   #"HTTP/1.1 404 Not Found\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n\"jazzy jazz\"")
 
  ; The message is normally inferred from the status code,
  ; but you can use whatever you want:
- (write-response (response/jsexpr #f
-                                  #:message #"Strange request"))
+ (write-response tm (response/jsexpr #f
+                                     #:message #"Strange request"))
  =>
  (bytes-sort
   #"HTTP/1.1 200 Strange request\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\nfalse")
@@ -48,8 +48,8 @@
           #"Date: [a-zA-Z0-9:, ]+ GMT"
           b
           #"Date: REDACTED GMT"))
-  (write-response (response/jsexpr (list "whoop" (hasheq 'there '("it" "is")))
-                                   #:seconds 0)
+  (write-response tm (response/jsexpr (list "whoop" (hasheq 'there '("it" "is")))
+                                      #:seconds 0)
                   #f))
  =>
  (bytes-sort
@@ -57,15 +57,15 @@
 
  ; The default MIME type ("application/json; charset=utf-8")
  ; can be overridden:
- (write-response (response/jsexpr ""
-                                  #:mime-type #"application/xml"))
+ (write-response tm (response/jsexpr ""
+                                     #:mime-type #"application/xml"))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/xml\r\n\r\n\"\"")
 
  ; Custom headers can be used:
- (write-response (response/jsexpr #t
-                                  #:headers (list (header #"head" #"bang"))))
+ (write-response tm (response/jsexpr #t
+                                     #:headers (list (header #"head" #"bang"))))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nhead: bang\r\n\r\ntrue"))

--- a/web-server-test/tests/web-server/http/json.rkt
+++ b/web-server-test/tests/web-server/http/json.rkt
@@ -1,0 +1,71 @@
+#lang racket
+
+(require tests/eli-tester
+         web-server/private/timer
+         web-server/private/connection-manager
+         web-server/http/response
+         web-server/http
+         "../util.rkt"
+         (file "util.rkt"))
+
+(define tm (start-timer-manager))
+
+(test
+ (write-response (response/jsexpr '("booga")))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\n\r\n[\"booga\"")
+
+ ; Showing off all default headers and other values (200, "OK"):
+ (write-response (response/jsexpr (hasheq 'jay "zee")))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n{\"jay\":\"zee\"}")
+
+ ; We respect the json-null parameter:
+ (write-response (parameterize ([json-null 'jibby-jab])
+                   (response/jsexpr 'jibby-jab)))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\nnull")
+
+ (write-response (response/jsexpr "jazzy jazz"
+                                  #:code 404))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 404 Not Found\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n\"jazzy jazz\"")
+
+ ; The message is normally inferred from the status code,
+ ; but you can use whatever you want:
+ (write-response (response/jsexpr #f
+                                  #:message #"Strange request"))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 Strange request\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\nfalse")
+
+ (map
+  (λ (b) (regexp-replace
+          #"Date: [a-zA-Z0-9:, ]+ GMT"
+          b
+          #"Date: REDACTED GMT"))
+  (write-response (response/jsexpr (list "whoop" (hasheq 'there '("it" "is")))
+                                   #:seconds 0)
+                  #f))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: Wed, 31 Dec 1969 23:00:00 GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n[\"whoop\",{\"there\":[\"it\",\"is\"]")
+
+ ; The default MIME type ("application/json; charset=utf-8")
+ ; can be overridden:
+ (write-response (response/jsexpr ""
+                                  #:mime-type #"application/xml"))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/xml\r\n\r\n\"\"")
+
+ ; Custom headers can be used:
+ (write-response (response/jsexpr #t
+                                  #:headers (list (header #"head" #"bang"))))
+ =>
+ (bytes-sort
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nhead: bang\r\n\r\ntrue"))

--- a/web-server-test/tests/web-server/http/util.rkt
+++ b/web-server-test/tests/web-server/http/util.rkt
@@ -1,0 +1,18 @@
+#lang racket
+
+(provide write-response)
+
+(require web-server/private/timer
+         web-server/private/connection-manager
+         web-server/http/response
+         (file "../util.rkt"))
+
+(define (write-response tm r [redact? #t])
+  (define-values (i-port o-port) (make-pipe))
+  (define conn
+    (connection 0 (start-timer tm +inf.0 void)
+                i-port o-port (make-custodian) #t))
+  (output-response conn r)
+  (close-output-port o-port)
+  (define bs (port->bytes i-port))
+  (bytes-sort (if redact? (redact bs) bs)))

--- a/web-server-test/tests/web-server/http/xexpr.rkt
+++ b/web-server-test/tests/web-server/http/xexpr.rkt
@@ -4,79 +4,71 @@
          web-server/private/connection-manager
          web-server/http/response
          web-server/http
-         "../util.rkt")
+         "../util.rkt"
+         (file "util.rkt"))
 
 (define tm (start-timer-manager))
-(define (write-response r [redact? #t])
-  (define-values (i-port o-port) (make-pipe))
-  (define conn
-    (connection 0 (start-timer tm +inf.0 void)
-                i-port o-port (make-custodian) #t))
-  (output-response conn r)
-  (close-output-port o-port)
-  (define bs (port->bytes i-port))
-  (bytes-sort (if redact? (redact bs) bs)))
 
 (test
- (write-response (response/xexpr '(a ([href "#"]) "link")))
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<a href=\"#\">link</a>")
 
- (write-response (response/xexpr '(html)))
+ (write-response tm (response/xexpr '(html)))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<html></html>")
 
- (write-response (response/xexpr '(img)))
+ (write-response tm (response/xexpr '(img)))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<img/>")
- 
- (write-response (response/xexpr '(a ([href "#"]) "link")
-                                 #:code 404))
+
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                    #:code 404))
  =>
  (bytes-sort
   #"HTTP/1.1 404 Not Found\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<a href=\"#\">link</a>")
- 
- (write-response (response/xexpr '(a ([href "#"]) "link")
-                                 #:message #"Bad request"))
+
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                    #:message #"Bad request"))
  =>
  (bytes-sort
   #"HTTP/1.1 200 Bad request\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<a href=\"#\">link</a>")
- 
+
  (map
-  (λ (b) (regexp-replace 
+  (λ (b) (regexp-replace
           #"Date: [a-zA-Z0-9:, ]+ GMT"
-          b          
+          b
           #"Date: REDACTED GMT"))
-  (write-response (response/xexpr '(a ([href "#"]) "link")
-                                  #:seconds 0)
+  (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                     #:seconds 0)
                   #f))
  =>
  (bytes-sort
-  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: Wed, 31 Dec 1969 23:00:00 GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n<a href=\"#\">link</a>")
- 
- (write-response (response/xexpr '(a ([href "#"]) "link")
-                                      #:mime-type #"application/xml"))
+  #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: Thu, 01 Jan 1970 00:00:00 GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n<a href=\"#\">link</a>")
+
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                    #:mime-type #"application/xml"))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: application/xml\r\n\r\n<a href=\"#\">link</a>")
- 
- (write-response (response/xexpr '(a ([href "#"]) "link")
-                                      #:headers (list (header #"head" #"value"))))
+
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                    #:headers (list (header #"head" #"value"))))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nhead: value\r\n\r\n<a href=\"#\">link</a>")
- 
- (write-response (response/xexpr '(a ([href "#"]) "link")
-                                      #:cookies (list (make-cookie "head" "value"))))
+
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                    #:cookies (list (make-cookie "head" "value"))))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nSet-Cookie: head=value\r\n\r\n<a href=\"#\">link</a>")
- 
- (write-response (response/xexpr '(a ([href "#"]) "link")
-                                      #:preamble #"<<!something XMLy>>"))
+
+ (write-response tm (response/xexpr '(a ([href "#"]) "link")
+                                    #:preamble #"<<!something XMLy>>"))
  =>
  (bytes-sort
   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<<!something XMLy>><a href=\"#\">link</a>"))


### PR DESCRIPTION
In this pull request we add a new convenience function for generating JSON-laden HTTP responses. It is to JSON what `response/xexpr` is to XML.