### PR TITLE
core: guard against RST packets during read

### DIFF
--- a/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
@@ -135,7 +135,7 @@
     ;; consume a byte, etc.
     (define (connection-loop)
       (cond
-        [(eof-object? (peek-bytes 1 0 ip))
+        [(eof-object? (peek-byte/safe ip))
          (kill-connection! conn)]
 
         [else
@@ -147,3 +147,7 @@
              (kill-connection! conn)
              (connection-loop))]))
     (connection-loop)))
+
+(define (peek-byte/safe ip)
+  (with-handlers ([exn:fail? (lambda _ eof)])
+    (peek-bytes 1 0 ip)))


### PR DESCRIPTION
This prevents errors such as

    tcp-read: error reading
      system error: Connection reset by peer; errno=54
      errortrace...:
      context...:
       /Applications/Racket v7.4/collects/racket/port.rkt:1160:4: try-again

from appearing in application output after clients terminate their connections abruptly (without sending a FIN packet).

This code can be used to exercise the problem:

```racket
#lang racket

(require racket/tcp)

(for ([_ (in-range 100)])
  (define-values (in out)
    (tcp-connect "127.0.0.1" 8000))

  (parameterize ([current-output-port out])
    (displayln "GET / HTTP/1.1")
    (displayln "")
    (flush-output))

  (read-string 100 in)

  (tcp-abandon-port in)
  (tcp-abandon-port out))
```