### PR TITLE
add CI via GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: Bogdanp/setup-racket@v0.1
+        with:
+          architecture: x64
+          distribution: full
+          variant: regular
+          version: 7.4
+      - run: sudo raco pkg update --name web-server-lib --link --batch --auto web-server-lib/
+      - run: sudo raco pkg install --batch --auto web-server-test/
+      - run: raco test --drdr web-server-test/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Racket web-server
 
-This is the main repository for the Racket web-server package.  
-  
-It is a simple yet powerful continuation-based web server, but you can use it without continuations if you like!  
-Check the [documentation](https://docs.racket-lang.org/web-server/) for a quick start guide.  
-There is also a [good tutorial](https://docs.racket-lang.org/continue/) on making a blog written by [Danny Yoo](https://github.com/dyoo) and [Jay McCarthy](https://github.com/jeapostrophe).  
+<p align="left">
+  <a href="https://github.com/racket/web-server">
+    <img alt="GitHub Actions status" src="https://github.com/racket/web-server/workflows/CI/badge.svg">
+  </a>
+</p>
+
+
+This is the main repository for the Racket web-server package.
+
+It is a simple yet powerful continuation-based web server, but you can use it without continuations if you like!
+Check the [documentation](https://docs.racket-lang.org/web-server/) for a quick start guide.
+There is also a [good tutorial](https://docs.racket-lang.org/continue/) on making a blog written by [Danny Yoo](https://github.com/dyoo) and [Jay McCarthy](https://github.com/jeapostrophe).
 
 ## How to contribute
 

--- a/web-server-test/tests/web-server/e2e/README.md
+++ b/web-server-test/tests/web-server/e2e/README.md
@@ -5,8 +5,8 @@ system works end-to-end.  Each subfolder is expected to contain two
 files: `server.rkt` and `tests.rkt`.
 
 Each `server.rkt` module must provide a function called `start` that
-starts a web server and returns a function that can be used to stop
-that server.
+takes a port, starts a web server on that port and returns a function
+that can be used to stop the server.
 
-Each `tests.rkt` module must provide a rackunit `test-suite` called
-`tests`.
+Each `tests.rkt` module must provide a function called `make-tests`
+that takes a port and returns a rackunit `test-suite`.

--- a/web-server-test/tests/web-server/e2e/echo/server.rkt
+++ b/web-server-test/tests/web-server/e2e/echo/server.rkt
@@ -15,7 +15,7 @@
    (lambda (out)
      (display msg out))))
 
-(define (start)
+(define (start port)
   (serve
-   #:port 9111
+   #:port port
    #:dispatch (dispatch/servlet echo)))

--- a/web-server-test/tests/web-server/e2e/echo/tests.rkt
+++ b/web-server-test/tests/web-server/e2e/echo/tests.rkt
@@ -4,31 +4,34 @@
          racket/port
          rackunit)
 
-(provide tests)
+(provide make-tests)
 
 (define get-response
   (compose1 port->string get-pure-port string->url))
 
-(define tests
+(define (make-tests port)
+  (define (make-uri [path "/"])
+    (format "http://127.0.0.1:~a/~a" port path))
+
   (test-suite
    "echo"
 
    (test-equal?
     "no query param"
-    (get-response "http://127.0.0.1:9111")
+    (get-response (make-uri))
     "nothing")
 
    (test-equal?
     "with empty query param"
-    (get-response "http://127.0.0.1:9111?message=")
+    (get-response (make-uri "?message="))
     "")
 
    (test-equal?
     "with query param"
-    (get-response "http://127.0.0.1:9111?message=hello")
+    (get-response (make-uri "?message=hello"))
     "hello")
 
    (test-equal?
     "with encoded param"
-    (get-response "http://127.0.0.1:9111?message=hello%3D%26")
+    (get-response (make-uri "?message=hello%3D%26"))
     "hello=&")))

--- a/web-server-test/tests/web-server/e2e/file-upload/server.rkt
+++ b/web-server-test/tests/web-server/e2e/file-upload/server.rkt
@@ -17,17 +17,14 @@
      (for ([h (in-list hashes)])
        (displayln h out)))))
 
-(define (start)
+(define (start port)
   ;; We're testing file limits and those end up raising exceptions in
   ;; the request-handling threads which get reported to stderr so we
   ;; need to drop those messages in order for drdr not to fail.
   (parameterize ([current-error-port (open-output-nowhere)])
     (serve
-     #:port 9112
+     #:port port
      #:dispatch (dispatch/servlet file-upload)
      #:max-request-files 2
      #:max-request-file-length 500
      #:max-request-file-memory-threshold 250)))
-
-(module+ main
-  (start))

--- a/web-server-test/tests/web-server/e2e/json/server.rkt
+++ b/web-server-test/tests/web-server/e2e/json/server.rkt
@@ -48,15 +48,12 @@
    [("books") #:method "post" add-book]
    [("books") all-books]))
 
-(define (start)
+(define (start port)
   ;; One of the tests tries to send invalid JSON, which causes the
   ;; request handler to throw an exception, which would normally get
   ;; logged to stderr. This swallows that logging to avoid failing drdr.
   (parameterize ([current-error-port (open-output-nowhere)])
     (serve
-     #:port 9113
+     #:port port
      #:dispatch (dispatch/servlet go)
      #:max-request-body-length 255)))
-
-(module+ main
-  (start))

--- a/web-server-test/tests/web-server/e2e/read-write/server.rkt
+++ b/web-server-test/tests/web-server/e2e/read-write/server.rkt
@@ -12,13 +12,10 @@
    (lambda (out)
      (display (request-post-data/raw req) out))))
 
-(define (start)
+(define (start port)
   (parameterize ([current-error-port (open-output-nowhere)])
     (serve
-     #:port 9114
-     #:dispatch (dispatch/servlet read-write)
-     #:request-read-timeout 1
-     #:response-send-timeout 1)))
-
-(module+ main
-  (start))
+      #:port port
+      #:dispatch (dispatch/servlet read-write)
+      #:request-read-timeout 1
+      #:response-send-timeout 1)))

--- a/web-server-test/tests/web-server/e2e/read-write/tests.rkt
+++ b/web-server-test/tests/web-server/e2e/read-write/tests.rkt
@@ -5,13 +5,13 @@
          racket/tcp
          rackunit)
 
-(provide tests)
+(provide make-tests)
 
 (define (broken-pipe? e)
   (and (exn:fail:network? e)
        (equal? (exn:fail:network:errno-errno e) '(32 . posix))))
 
-(define tests
+(define (make-tests port)
   (test-suite
    "read-write"
 
@@ -20,7 +20,7 @@
       "hello world"
       (port->string
        (post-pure-port
-        (string->url "http://127.0.0.1:9114")
+        (string->url (format "http://127.0.0.1:~a" port))
         #"hello world"))))
 
    (test-exn
@@ -28,7 +28,7 @@
     broken-pipe?
     (lambda _
       (define-values (in out)
-        (tcp-connect "127.0.0.1" 9114))
+        (tcp-connect "127.0.0.1" port))
 
       (parameterize ([current-output-port out])
         (for ([c (in-string "POST / HTTP/1.1\r\n")])

--- a/web-server-test/tests/web-server/e2e/tls/server.rkt
+++ b/web-server-test/tests/web-server/e2e/tls/server.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require web-server/servlet
+(require racket/port
+         web-server/servlet
          web-server/servlet-dispatch
          web-server/web-server)
 
@@ -15,12 +16,10 @@
    (lambda (out)
      (display "success!" out))))
 
-(define (start)
-  (serve
-   #:port 9115
-   #:dispatch (dispatch/servlet hello)
-   #:dispatch-server-connect@ (make-ssl-connect@ (build-path here "cert.pem")
-                                                 (build-path here "key.pem"))))
-
-(module+ main
-  (start))
+(define (start port)
+  (parameterize ([current-error-port (open-output-nowhere)])
+    (serve
+     #:port port
+     #:dispatch (dispatch/servlet hello)
+     #:dispatch-server-connect@ (make-ssl-connect@ (build-path here "cert.pem")
+                                                   (build-path here "key.pem")))))

--- a/web-server-test/tests/web-server/e2e/tls/server.rkt
+++ b/web-server-test/tests/web-server/e2e/tls/server.rkt
@@ -17,7 +17,7 @@
 
 (define (start)
   (serve
-   #:port 9111
+   #:port 9115
    #:dispatch (dispatch/servlet hello)
    #:dispatch-server-connect@ (make-ssl-connect@ (build-path here "cert.pem")
                                                  (build-path here "key.pem"))))

--- a/web-server-test/tests/web-server/e2e/tls/tests.rkt
+++ b/web-server-test/tests/web-server/e2e/tls/tests.rkt
@@ -4,13 +4,13 @@
          racket/port
          rackunit)
 
-(provide tests)
+(provide make-tests)
 
-(define tests
+(define (make-tests port)
   (test-suite
    "tls"
 
    (test-equal?
     "can get data"
-    (port->string (get-pure-port (string->url "https://127.0.0.1:9115")))
+    (port->string (get-pure-port (string->url (format "https://127.0.0.1:~a" port))))
     "success!")))


### PR DESCRIPTION
I noticed how much additional work my last PR required (sorry @jeapostrophe !) to get working on drdr so I figured this repo could use CI of its own. [GH Actions](https://github.com/features/actions) are turning GA on November 13 and they're pretty convenient for this sort of thing.

You can see an example CI run [here](https://github.com/bogdanp/web-server/commit/c7855c4b3652190ff84a7803e11e9b01fbe27cb3/checks?check_suite_id=292872259).

EDIT: I added another commit to make the e2e tests wait for each server to become available before running their tests.