### PR TITLE
ci: build against multiple Racket versions and variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,20 @@ on: [push, pull_request]
 name: CI
 jobs:
   build:
+    name: "Build on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        racket-version: ["7.4", "current"]
+        racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.1
+      - uses: Bogdanp/setup-racket@v0.2
         with:
           architecture: x64
           distribution: full
-          variant: regular
-          version: 7.4
+          variant: ${{ matrix.racket-variant }}
+          version: ${{ matrix.racket-version }}
       - run: sudo raco pkg update --name web-server-lib --link --batch --auto web-server-lib/
       - run: sudo raco pkg install --batch --auto web-server-test/
       - run: raco test --drdr web-server-test/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This the source for the Racket packages: "web-server", "web-server-doc", "web-server-lib", "web-server-test".
 
 <p align="left">
-  <a href="https://github.com/racket/web-server">
+  <a href="https://github.com/racket/web-server/actions?query=workflow%3A%22CI%22">
     <img alt="GitHub Actions status" src="https://github.com/racket/web-server/workflows/CI/badge.svg">
   </a>
 </p>

--- a/web-server-test/tests/web-server/e2e/read-write/tests.rkt
+++ b/web-server-test/tests/web-server/e2e/read-write/tests.rkt
@@ -27,11 +27,15 @@
     "sending data too slowly"
     broken-pipe?
     (lambda _
-      (define-values (in out)
-        (tcp-connect "127.0.0.1" port))
+      ;; On Racket CS 7.4 the default plumber writes an error to
+      ;; standard out when it tries to close the socket. Creating a
+      ;; custom plumber seems to fix that problem.
+      (parameterize ([current-plumber (make-plumber)])
+        (define-values (in out)
+          (tcp-connect "127.0.0.1" port))
 
-      (parameterize ([current-output-port out])
-        (for ([c (in-string "POST / HTTP/1.1\r\n")])
-          (display c)
-          (flush-output)
-          (sleep 0.25)))))))
+        (parameterize ([current-output-port out])
+          (for ([c (in-string "POST / HTTP/1.1\r\n")])
+            (display c)
+            (flush-output)
+            (sleep 0.25))))))))


### PR DESCRIPTION
With this change, every push and pull request will be tested against both variants of Racket 7.4 as well as both variants of the latest snapshot.