### PR TITLE
request: provide read-headers and parse-bindings

### DIFF
--- a/web-server-lib/web-server/http/request.rkt
+++ b/web-server-lib/web-server/http/request.rkt
@@ -26,8 +26,8 @@
 ;; Happy hacking!
 ;;
 
-(define positive-real/c
-  (and/c real? positive?))
+(define nonnegative-length/c
+  (or/c exact-nonnegative-integer? +inf.0))
 
 (define read-request/c
   (connection?
@@ -39,8 +39,8 @@
 (provide/contract
  [parse-bindings (-> bytes? (listof binding?))]
  [read-headers (->* (input-port?)
-                    (positive-real/c
-                     positive-real/c)
+                    (nonnegative-length/c
+                     nonnegative-length/c)
                     (listof header?))]
 
  [rename make-ext:read-request


### PR DESCRIPTION
It looks like some packages (eg. rfc6455) were depending on these despite them not being documented.

Closes #80.