### PR TITLE
Make empty responses

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -381,6 +381,11 @@ Equivalent to
 Generates a response with an empty body. The usual @tt{Content-Type} header will be absent, unless passed in via @racket[headers]. Equivalent to
 @racketblock[(response code message seconds #f headers (λ (o) (write-bytes #"" o)))], with the understanding that if @racket[message] is missing (or @racket[#f]), it will be inferred from @racket[code] using the association between status codes and messages found in RFCs 7231 and 7235. See the documentation for @racket[response/full] for the table of built-in status codes.
 
+@history[
+  #:added "1.6"
+  @elem{First introduced.}]
+}
+
 @defthing[TEXT/HTML-MIME-TYPE bytes?]{Equivalent to @racket[#"text/html; charset=utf-8"].}
 
 @defthing[APPLICATION/JSON-MIME-TYPE bytes?]{Equivalent to @racket[#"application/json; charset=utf-8"].}

--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -372,6 +372,15 @@ Equivalent to
                as the result (instead of demanding @racket[void?]).}]
 }
 
+@defproc[(response/empty [#:code code number? 200]
+                         [#:message message (or/c false/c bytes?) #f]
+                         [#:cookies cookies (listof cookie?) '()]
+                         [#:seconds seconds number? (current-seconds)]
+                         [#:headers headers (listof header?) '()])
+         response?]{
+Generates a response with an empty body. The usual @tt{Content-Type} header will be absent, unless passed in via @racket[headers]. Equivalent to
+@racketblock[(response code message seconds #f headers (λ (o) (write-bytes #"" o)))], with the understanding that if @racket[message] is missing (or @racket[#f]), it will be inferred from @racket[code] using the association between status codes and messages found in RFCs 7231 and 7235. See the documentation for @racket[response/full] for the table of built-in status codes.
+
 @defthing[TEXT/HTML-MIME-TYPE bytes?]{Equivalent to @racket[#"text/html; charset=utf-8"].}
 
 @defthing[APPLICATION/JSON-MIME-TYPE bytes?]{Equivalent to @racket[#"application/json; charset=utf-8"].}

--- a/web-server-lib/web-server/http/empty.rkt
+++ b/web-server-lib/web-server/http/empty.rkt
@@ -1,0 +1,34 @@
+#lang racket/base
+
+(require racket/contract
+         (except-in net/cookies/server
+                    make-cookie)
+         (file "request-structs.rkt")
+         (file "response-structs.rkt")
+         (file "cookie.rkt")
+         (file "status-code.rkt"))
+
+(module+ test
+  (require rackunit))
+
+(define (response/empty
+         #:code [code 200]
+         #:message [message #f]
+         #:seconds [seconds (current-seconds)]
+         #:cookies [cooks '()]
+         #:headers [hdrs '()])
+  (response
+   code (infer-response-message code message) seconds #f
+   ; rfc2109 also recommends some cache-control stuff here for cookies
+   (append hdrs (map cookie->header cooks))
+   (λ (out) (write-bytes #"" out))))
+
+(provide/contract
+ [response/empty
+  (()
+   (#:code response-code/c
+    #:message (or/c #f bytes?)
+    #:seconds real?
+    #:cookies (listof cookie?)
+    #:headers (listof header?))
+   . ->* . response?)])


### PR DESCRIPTION
In some HTTP API settings (e.g., JSON RPC) it is convenient to provide empty HTTP responses. This change adds a little convenience, `response/empty`, for such responses.