### PR TITLE
CI on 7.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["7.4", "current"]
+        racket-version: ["7.4", "7.5", "current"]
         racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.2
+      - uses: Bogdanp/setup-racket@v0.3
         with:
           architecture: x64
           distribution: full


### PR DESCRIPTION
This change adds both variants of Racket 7.5 to the build matrix.