### PR TITLE
Move response/empty to http/request-structs.rkt.

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -430,18 +430,6 @@ Equivalent to
                as the result (instead of demanding @racket[void?]).}]
 }
 
-@defproc[(response/empty [#:code code number? 200]
-                         [#:message message (or/c false/c bytes?) #f]
-                         [#:cookies cookies (listof cookie?) '()]
-                         [#:seconds seconds number? (current-seconds)]
-                         [#:headers headers (listof header?) '()])
-         response?]{
-Generates a response with an empty body. The usual @tt{Content-Type} header will be absent, unless passed in via @racket[headers]. Equivalent to
-@racketblock[(response code message seconds #f headers (λ (o) (write-bytes #"" o)))], with the understanding that if @racket[message] is missing (or @racket[#f]), it will be inferred from @racket[code] using the association between status codes and messages found in RFCs 7231 and 7235. See the documentation for @racket[response/full] for the table of built-in status codes.
-
-@history[#:added "1.6"]
-}
-
 @defthing[TEXT/HTML-MIME-TYPE bytes?]{Equivalent to @racket[#"text/html; charset=utf-8"].}
 
 @defthing[APPLICATION/JSON-MIME-TYPE bytes?]{Equivalent to @racket[#"application/json; charset=utf-8"].}
@@ -1049,6 +1037,23 @@ web-server/insta
          #:changed "1.3"
           @elem{Updated contracts on @racket[code] and @racket[seconds]
              as with @racket[response].}]
+}
+
+@section[#:tag "empty"]{Empty Responses}
+@(require (for-label web-server/http))
+
+@defmodule[web-server/http]
+
+@defproc[(response/empty [#:code code number? 200]
+                         [#:message message (or/c false/c bytes?) #f]
+                         [#:cookies cookies (listof cookie?) '()]
+                         [#:seconds seconds number? (current-seconds)]
+                         [#:headers headers (listof header?) '()])
+         response?]{
+Generates a response with an empty body. The usual @tt{Content-Type} header will be absent, unless passed in via @racket[headers]. Equivalent to
+@racketblock[(response code message seconds #f headers (λ (o) (write-bytes #"" o)))], with the understanding that if @racket[message] is missing (or @racket[#f]), it will be inferred from @racket[code] using the association between status codes and messages found in RFCs 7231 and 7235. See the documentation for @racket[response/full] for the table of built-in status codes.
+
+@history[#:added "1.6"]
 }
 
 @section[#:tag "json"]{JSON Support}

--- a/web-server-lib/web-server/http.rkt
+++ b/web-server-lib/web-server/http.rkt
@@ -7,7 +7,8 @@
          web-server/http/cookie-parse
          web-server/http/redirect
          web-server/http/xexpr
-         web-server/http/json)
+         web-server/http/empty
+         web-server/http/json         )
 (provide (all-from-out web-server/http/basic-auth
                        web-server/http/digest-auth
                        web-server/http/request-structs
@@ -16,4 +17,5 @@
                        web-server/http/cookie-parse
                        web-server/http/redirect
                        web-server/http/xexpr
+                       web-server/http/empty
                        web-server/http/json))


### PR DESCRIPTION
The documentation incorrectly implies that `response/empty`
is in the `web-server/http/response-structs` module.  You
can see this if you look at

  https://docs.racket-lang.org/search/index.html?q=response%2Fempty

for 7.6. But this isn't true: if you use `response/empty` after `require`ing `web-server/http/response-structs`, you'll get an unbound identifier error. `response/empty` is actually provided from `web-server/http/empty`.

Rather than viewing this as a problem with the
documentation, the solution here is to incorporate
`response/empty`, which is currently defined in a little
module `empty.rkt`, into `response-structs.rkt`. It thus
sites alongside other utilities such as `response/full` and
`response/output`.