### PR TITLE
New dispatcher constructor based on HTTP request method

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -166,6 +166,19 @@ URLs to paths on the filesystem.
 }}
 
 @; ------------------------------------------------------------
+@section[#:tag "dispatch-method"]{Filtering Requests by Method}
+@a-dispatcher[web-server/dispatchers/dispatch-method
+              @elem{defines a dispatcher constructor
+                 that calls an underlying dispatcher
+                 provided the request method belongs to a given list.}]{
+
+@defproc[(make (method (or/c symbol? (listof symbol?))) (inner dispatcher/c))
+         dispatcher/c]{
+ Calls @racket[inner] if the method of the request, converted to
+ a string, case-insensitively matches @racket[method] (if method is a symbol, or, if a list, one of the elements of @racket[method]). Otherwise, calls @racket[next-dispatcher].
+}}
+
+@; ------------------------------------------------------------
 @section[#:tag "dispatch-pathprocedure"]{Procedure Invocation upon Request}
 @a-dispatcher[web-server/dispatchers/dispatch-pathprocedure
               @elem{defines a dispatcher constructor

--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -153,7 +153,7 @@ URLs to paths on the filesystem.
 }}
 
 @; ------------------------------------------------------------
-@section[#:tag "dispatch-filter"]{Filtering Requests}
+@section[#:tag "dispatch-filter"]{Filtering Requests by URL}
 @a-dispatcher[web-server/dispatchers/dispatch-filter
               @elem{defines a dispatcher constructor
                  that calls an underlying dispatcher

--- a/web-server-lib/web-server/dispatchers/dispatch-method.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-method.rkt
@@ -1,0 +1,39 @@
+#lang racket/base
+
+(require racket/contract
+         web-server/dispatchers/dispatch
+         web-server/http
+         (only-in "../private/util.rkt"
+                  bytes-ci=?))
+
+(provide/contract
+ [interface-version dispatcher-interface-version/c]
+ [make (-> (or/c symbol? (cons/c symbol? (listof symbol?)))
+           dispatcher/c
+           dispatcher/c)])
+
+(define interface-version 'v1)
+
+; symbol? -> bytes?
+;
+; uppercase the (name of the) symbol to optimized for the
+; normal case, where HTTP methods are given in uppercase
+; ("GET", "HEAD", etc.)
+(define (symbol->bytes symb)
+  (string->bytes/utf-8 (string-upcase (symbol->string symb))))
+
+; request? (listof bytes?) -> boolean?
+(define (can-request-pass-through? req methods)
+  (member (request-method req)
+          methods
+          bytes-ci=?))
+
+(define (make methods inner)
+  (define methods/bytes/list
+    (if (symbol? methods)
+        (list (symbol->bytes methods))
+        (map symbol->bytes methods)))
+  (lambda (conn req)
+    (cond [(can-request-pass-through? req methods/bytes/list)
+           (inner conn req)]
+          [else (next-dispatcher)])))

--- a/web-server-test/tests/web-server/dispatchers/dispatch-method.rkt
+++ b/web-server-test/tests/web-server/dispatchers/dispatch-method.rkt
@@ -1,0 +1,58 @@
+#lang racket/base
+
+(require rackunit
+         racket/promise
+         racket/match
+         net/url
+         web-server/http/request-structs
+         web-server/dispatchers/dispatch
+         (prefix-in method: web-server/dispatchers/dispatch-method)
+         "../util.rkt")
+
+; connection? request? -> symbol?
+(define (do-nothing-dispatcher conn req)
+  'do-nothing)
+
+; bytes? -> request?
+(define (fake-request-for-method method)
+  (request method
+           (string->url "whatever")
+           (list)
+           (delay (list))
+           #f
+           "localhost"
+           80
+           "whatever"))
+
+; bytes? -> connection?
+(define (fake-connection-for-bytes bstr)
+  (define-values (c i o) (make-mock-connection bstr))
+  c)
+
+; method matches
+(let ([d (method:make '(get) do-nothing-dispatcher)]
+      [r (fake-request-for-method #"GET")]
+      [c (fake-connection-for-bytes #"")])
+  (check-equal? 'do-nothing
+                (d c r)))
+
+; method (single symbol, uppercase name)
+(let ([d (method:make 'GET do-nothing-dispatcher)]
+      [r (fake-request-for-method #"gEt")]
+      [c (fake-connection-for-bytes #"")])
+  (check-equal? 'do-nothing
+                (d c r)))
+
+; method does not match multiple options
+(let ([d (method:make '(get head) do-nothing-dispatcher)]
+      [r (fake-request-for-method #"OPTIONS")]
+      [c (fake-connection-for-bytes #"")])
+  (check-exn exn:dispatcher?
+             (lambda () (d c r))))
+
+; no match, excception
+(let ([d (method:make 'POST do-nothing-dispatcher)]
+      [r (fake-request-for-method #"GET")]
+      [c (fake-connection-for-bytes #"")])
+  (check-exn exn:dispatcher?
+             (lambda () (d c r))))


### PR DESCRIPTION
The purpose of this change is to be able to filter requests by their method.

Motivation: Many servers don't handle arbitrary HTTP methods, but only a handful of some standard ones; and even then, a smaller sub-handful of methods are the only ones that are actually supported (e.g., GET and HEAD only).

One can use `dispatch-rules` and variants thereof for fine-grained dispatching based on the request method.  But, to be complete, one ought to provide a fallback in every case (e.g., a request-method-not-allowed servlet, where the method matches `(regexp ".*")`.). Adding a request-method-not-allowed rule for every URL in `dispatch-rules` can decrease code readability. With the kind of functionality introduced here, one can say, at the outset, that all requests have a known HTTP method (e.g, only GET and HEAD); nothing else will ever be considered.

Combining this dispatcher constructor with `dispatch-rules` and the sequencing dispatcher constructor makes for more readable code, in my view.