### PR TITLE
test: deflake connection-manager-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["7.5", "current"]
+        racket-version: ["7.5", "7.6", "current"]
         racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master

--- a/web-server-lib/web-server/private/timer.rkt
+++ b/web-server-lib/web-server/private/timer.rkt
@@ -115,4 +115,5 @@
  [start-timer (timer-manager? number? (-> any/c) . -> . timer?)]
  [reset-timer! (timer? number? . -> . any/c)]
  [increment-timer! (timer? number? . -> . any/c)]
+ [revise-timer! (timer? number? (-> any/c) . -> . void?)]
  [cancel-timer! (timer? . -> . any/c)])

--- a/web-server-test/tests/web-server/private/connection-manager-test.rkt
+++ b/web-server-test/tests/web-server/private/connection-manager-test.rkt
@@ -82,6 +82,7 @@
    (test-case "Extend timer"
      (define ib (open-input-bytes #""))
      (define ob (open-output-bytes))
+     (define st (current-inexact-milliseconds))
      (define-values (conn evt)
        (make-connection&evt 1 ib ob))
 
@@ -93,4 +94,5 @@
                (read ib)))
            (with-handlers ([exn? (lambda _ #t)])
              (begin0 #f
-               (write 1 ob))))))))
+               (write 1 ob)))
+           (>= (- (current-inexact-milliseconds) st) 2000))))))

--- a/web-server-test/tests/web-server/private/connection-manager-test.rkt
+++ b/web-server-test/tests/web-server/private/connection-manager-test.rkt
@@ -1,60 +1,96 @@
 #lang racket/base
 (require rackunit
-         web-server/private/connection-manager)
+         web-server/private/connection-manager
+         web-server/private/timer)
 (provide connection-manager-tests)
-
-(define cm (start-connection-manager))
 
 (module+ test
   (require rackunit/text-ui)
   (run-tests connection-manager-tests))
 
+(define cm (start-connection-manager))
+
+(define (make-connection&evt ttl ib ob [cust (make-custodian)] [close? #t])
+  (define conn
+    (new-connection cm ttl ib ob cust close?))
+
+  ;; Modify the timer s.t. it fires an event when its action completes.
+  ;; This means we don't have to rely on static sleeps to test this
+  ;; code, although it does couple the tests to the implementation.
+  (define chan (make-channel))
+  (define timer (connection-timer conn))
+  (define action (timer-action timer))
+  (revise-timer!
+   timer
+   (max 0 (- (timer-expire-seconds timer)
+             (current-inexact-milliseconds)))
+   (lambda ()
+     (dynamic-wind
+       void
+       action
+       (lambda ()
+         (channel-put chan 'done)))))
+
+  ;; Ensure the connection object is retained for longer than the
+  ;; timer, otherwise things will flake out.
+  (define evt (handle-evt chan (lambda _ conn)))
+  (values conn evt))
+
 (define connection-manager-tests
   (test-suite
    "Connection Manager"
-   
-   ; (tests rely on timing and may fail for that reason)
-   (test-case
-    "Input closed"
-    (check-true
-     (let ([ib (open-input-bytes #"")]
-           [ob (open-output-bytes)])
-       (new-connection cm 1 ib ob (make-custodian) #t)
-       (sleep 2)
-       (with-handlers ([exn? (lambda _ #t)])
-         (read ib) #f))))
-   
-   (test-case
-    "Output closed"
-    (check-true
-     (let ([ib (open-input-bytes #"")]
-           [ob (open-output-bytes)])
-       (new-connection cm 1 ib ob (make-custodian) #t)
-       (sleep 2)
-       (with-handlers ([exn? (lambda _ #t)])
-         (write 1 ob) #f))))
-   
-   (test-case
-    "Early kill"
-    (check-true
-     (let* ([ib (open-input-bytes #"")]
-            [ob (open-output-bytes)]
-            [c (new-connection cm 1 ib ob (make-custodian) #t)])
-       (kill-connection! c)
-       (and (with-handlers ([exn? (lambda _ #t)])
-              (read ib) #f)
-            (with-handlers ([exn? (lambda _ #t)])
-              (write 1 ob) #f)))))
-   
-   (test-case
-    "Extend timer"
-    (check-true
-     (let* ([ib (open-input-bytes #"")]
-            [ob (open-output-bytes)]
-            [c (new-connection cm 2 ib ob (make-custodian) #t)])
-       (adjust-connection-timeout! c 1)
-       (sleep 4)
-       (and (with-handlers ([exn? (lambda _ #t)])
-              (read ib) #f)
-            (with-handlers ([exn? (lambda _ #t)])
-              (write 1 ob) #f)))))))
+
+   (test-case "Input closed"
+     (define ib (open-input-bytes #""))
+     (define ob (open-output-bytes))
+     (define-values (_conn evt)
+       (make-connection&evt 1 ib ob))
+
+     (sync/timeout 10 evt)
+     (check-true
+      (with-handlers ([exn? (lambda _ #t)])
+        (begin0 #f
+          (read ib)))))
+
+   (test-case "Output closed"
+     (define ib (open-input-bytes #""))
+     (define ob (open-output-bytes))
+     (define-values (_conn evt)
+       (make-connection&evt 1 ib ob))
+
+     (sync/timeout 10 evt)
+     (check-true
+      (with-handlers ([exn? (lambda _ #t)])
+        (begin0 #f
+          (write 1 ob)))))
+
+   (test-case "Early kill"
+     (define ib (open-input-bytes #""))
+     (define ob (open-output-bytes))
+     (define-values (conn evt)
+       (make-connection&evt 1 ib ob))
+
+     (kill-connection! conn)
+     (check-true
+      (and (with-handlers ([exn? (lambda _ #t)])
+             (begin0 #f
+               (read ib)))
+           (with-handlers ([exn? (lambda _ #t)])
+             (begin0 #f
+               (write 1 ob))))))
+
+   (test-case "Extend timer"
+     (define ib (open-input-bytes #""))
+     (define ob (open-output-bytes))
+     (define-values (conn evt)
+       (make-connection&evt 1 ib ob))
+
+     (adjust-connection-timeout! conn 1)
+     (sync/timeout 20 evt)
+     (check-true
+      (and (with-handlers ([exn? (lambda _ #t)])
+             (begin0 #f
+               (read ib)))
+           (with-handlers ([exn? (lambda _ #t)])
+             (begin0 #f
+               (write 1 ob))))))))


### PR DESCRIPTION
This potentially fixes #88.

There were two issues:

* the tests relied on timing to work correctly and
* the connection object could be garbage collected before the timers
ran because the tests never used the connections.

I've changed the tests so they now synchronize based on events and
laid out the code so that the connections should be retained at least
for as long as needed for their timers to fire.