### PR TITLE
Allow symbol in dispatch-log's make to specify a logger

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -254,15 +254,20 @@ a URL that refreshes the password file, servlet cache, etc.}
  @racket['apache-default] to @racket[apache-default-format].
 }
 
-@defproc[(make [#:format format format-req/c paren-format]
+@defproc[(make [#:format format (or/c log-format/c format-req/c) paren-format]
                [#:log-path log-path (or/c path-string? output-port?) "log"])
          dispatcher/c]{
  Logs requests to @racket[log-path], which can be either a filepath or an @racket[output-port?],
- using @racket[format] to format the requests.
+ using @racket[format] to format the requests. (If @racket[format] is a symbol, a log formatter
+ will be tacitly made using @racket[log-format->format].)
  Then invokes @racket[next-dispatcher].
 
- @history[#:changed "1.3"
-          @elem{Allow @racket[log-path] to be an @racket[output-port?]}]
+ @history[
+   #:changed "1.3"
+   @elem{Allow @racket[log-path] to be an @racket[output-port?]}
+   #:changed "1.8"
+   @elem{Allow @racket[format] to be a symbol (more precisely, a @racket[log-format/c]).}
+]
 }}
 
 @; ------------------------------------------------------------

--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -207,7 +207,7 @@ a URL that refreshes the password file, servlet cache, etc.}
 @defthing[paren-format format-req/c]{
  Formats a request by:
  @racketblock[
-  (format 
+  (format
    "~s\n"
    (list 'from (request-client-ip req)
          'to (request-host-ip req)
@@ -219,12 +219,12 @@ a URL that refreshes the password file, servlet cache, etc.}
 @defthing[extended-format format-req/c]{
  Formats a request by:
  @racketblock[
-  (format 
+  (format
    "~s\n"
    `((client-ip ,(request-client-ip req))
      (host-ip ,(request-host-ip req))
-     (referer 
-      ,(let ([R (headers-assq* 
+     (referer
+      ,(let ([R (headers-assq*
                  #"Referer"
                  (request-headers/raw req))])
          (if R
@@ -354,7 +354,7 @@ Creates a denied procedure from an authorized procedure.
                [#:indices indices (listof string?) (list "index.html" "index.htm")])
          dispatcher/c]{
  Uses @racket[url->path] to extract a path from the URL in the request
- object. If this path does not exist, then the dispatcher does not apply and 
+ object. If this path does not exist, then the dispatcher does not apply and
  @racket[next-dispatcher] is invoked.
  If the path is a directory, then the @racket[indices] are checked in order
  for an index file to serve. In that case, or in the case of a path that is
@@ -395,7 +395,7 @@ Creates a denied procedure from an authorized procedure.
          thread?]{
  Starts a thread that calls @racket[(collect-garbage)] every @racket[time] seconds.
 }
-                 
+
 @defproc[(make)
          dispatcher/c]{
  Returns a dispatcher that prints memory usage on every request.
@@ -411,7 +411,7 @@ Creates a denied procedure from an authorized procedure.
                [#:over-limit over-limit (symbols 'block 'kill-new 'kill-old) 'block])
          dispatcher/c]{
  Returns a dispatcher that defers to @racket[inner] for work, but will forward a maximum of @racket[limit] requests concurrently.
-         
+
  If there are no additional spaces inside the limit and a new request is received, the @racket[over-limit] option determines what is done.
  The default (@racket['block]) causes the new request to block until an old request is finished being handled.
  If @racket[over-limit] is @racket['kill-new], then the new request handler is killed---a form of load-shedding.
@@ -429,7 +429,7 @@ Creates a denied procedure from an authorized procedure.
 Consider this example:
 @racketmod[
  racket
- 
+
 (require web-server/web-server
          web-server/http
          web-server/http/response
@@ -456,7 +456,7 @@ Consider this example:
                                   <)))))
              (request-method req)))
           #:over-limit 'block))
-        (lambda (conn req)          
+        (lambda (conn req)
           (output-response/method
            conn
            (response/full 200 #"Okay"

--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -239,7 +239,7 @@ a URL that refreshes the password file, servlet cache, etc.}
  Formats a request like Apache's default. However, Apache's default
  includes information about the response to a request, which this
  function does not have access to, so it defaults the last two fields
- to 200 and 512.
+ to @racket[200] and @racket[512].
 
 }
 

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -15,4 +15,4 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.7")
+(define version "1.8")

--- a/web-server-lib/web-server/dispatchers/dispatch-log.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-log.rkt
@@ -6,7 +6,7 @@
          racket/match
          racket/contract)
 (require web-server/dispatchers/dispatch
-         web-server/http)  
+         web-server/http)
 (define format-req/c (request? . -> . string?))
 (define log-format/c (symbols 'parenthesized-default 'extended 'apache-default))
 
@@ -71,7 +71,7 @@
             (referer ,(let ([R (headers-assq* #"Referer" (request-headers/raw req))])
                         (if R
                             (header-value R)
-                            #f)))                                              
+                            #f)))
             (uri ,(url->string (request-uri req)))
             (time ,(current-seconds)))))
 
@@ -82,7 +82,7 @@
      (lambda ()
        (let loop ([log-p #f])
          (sync
-          (handle-evt 
+          (handle-evt
            log-ch
            (match-lambda
              [(list req)

--- a/web-server-lib/web-server/dispatchers/dispatch-log.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-log.rkt
@@ -19,14 +19,18 @@
  [apache-default-format format-req/c]
  [interface-version dispatcher-interface-version/c]
  [make (->* ()
-            (#:format format-req/c
+            (#:format (or/c log-format/c format-req/c)
              #:log-path (or/c path-string? output-port?))
             dispatcher/c)])
 
 (define interface-version 'v1)
 (define (make #:format [format paren-format]
               #:log-path [log-path "log"])
-  (define log-message (make-log-message log-path format))
+  (define final-format
+    (if (symbol? format)
+        (log-format->format format)
+        format))
+  (define log-message (make-log-message log-path final-format))
   (lambda (conn req)
     (log-message req)
     (next-dispatcher)))


### PR DESCRIPTION
`dispatch-log`'s `make` expects a function for its log formatter. But the module also exports a utility, `log-format->format`, which takes a symbol and makes a log formatter. Presumably, the common way of invoking `dispatch-log`'s `make` is to call that helper with a symbol, thereby making a suitable log formatter function.

Why not spare a step there?

As a convenience, the change here allows us to specify a log formatter by giving a symbol, which is then passed to `log-format->format`. The symbol lookup (that is, the call to `log-format->format`) happens only once, when `make` is evaluated, so there's no interesting slowdown to be expected with this new convenience.

This change widens `dispatch-log`'s `make` contract, so the change should be backwards compatible.

Apart from that, there are some excess end-of-line whitespace trimmings here.