### PR TITLE
Add response codes 206 and 308

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -370,6 +370,7 @@ Examples:
    (list "203" "Non-Authoritative Information")
    (list "204" "No Content")
    (list "205" "Reset Content")
+   (list "206" "Partial Content")
 
    (list "300" "Multiple Choices")
    (list "301" "Moved Permanently")
@@ -377,6 +378,7 @@ Examples:
    (list "303" "See Other")
    (list "305" "Use Proxy")
    (list "307" "Temporary Redirect")
+   (list "308" "Permanent Redirect")
 
    (list "400" "Bad Request")
    (list "401" "Unauthorized")

--- a/web-server-lib/web-server/http/status-code.rkt
+++ b/web-server-lib/web-server/http/status-code.rkt
@@ -37,6 +37,7 @@
    203 "Non-Authoritative Information"
    204 "No Content"
    205 "Reset Content"
+   206 "Partial Content" ; RFC 7233
 
    300 "Multiple Choices"
    301 "Moved Permanently"
@@ -44,6 +45,7 @@
    303 "See Other"
    305 "Use Proxy"
    307 "Temporary Redirect"
+   308 "Permanent Redirect" ; RFC 7538
 
    400 "Bad Request"
    401 "Unauthorized"
@@ -73,8 +75,8 @@
 (module+ test
   (check-equal?
    (list 100 101
-         200 201 202 203 204 205
-         300 301 302 303 305 307
+         200 201 202 203 204 205 206
+         300 301 302 303 305 307 308
          400 401 402 403 404 405 406 407 408 409 410 411 413 414 415 417 426
          500 501 502 503 504 505)
    (sort (hash-keys common-http-status-codes&messages) <)))


### PR DESCRIPTION
Response code 206 is "Partial Content" and 308 is "Permanent
Redirect". According to the Mozilla trackers for these
codes,

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206

and

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308

206 appears to be supported across the board. 308 is largely
supported, though some old browsers may do the wrong thing
when given these codes. (The docs already mention this
caveat, and it makes sense to keep the notes there
unchanged.)

Nonetheless, this change should be OK. Adding support for
these codes does not mean that the web server starts
producing unexpected 308 responses. Rather, the change
amounts to this: if the web server is asked to render a
response in which the code is 206 or 308, it generates a
suitable status message. It was, and remains, up to the
programmer to decide whether to use 308 at all, given that
it may not do the right thing for some older browsers.