### PR TITLE
response: terminate failed responses early in responder

### DIFF
--- a/web-server-lib/web-server/dispatchers/dispatch-servlets.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-servlets.rkt
@@ -96,5 +96,5 @@
                   (lambda ()
                     ((servlet-handler the-servlet) req))
                   servlet-prompt)))))))
-      
-      (output-response conn (any->response maybe-response)))))
+
+      (output-response/method conn (any->response maybe-response) (request-method req)))))

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -141,9 +141,10 @@
     (thread (λ ()
               (with-handlers ([exn:fail?
                                (lambda (e)
-                                 ((error-display-handler) (exn-message e) e))])
-                ((response-output bresp) to-chunker))
-              (close-output-port to-chunker))))
+                                 (close-output-port to-chunker)
+                                 (raise e))])
+                ((response-output bresp) to-chunker)
+                (close-output-port to-chunker)))))
 
   ;; The client might go away while the response is being generated,
   ;; in which case the output port will be closed so we have to

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -139,7 +139,10 @@
   (define to-client (connection-o-port conn))
   (define to-chunker-t
     (thread (λ ()
-              ((response-output bresp) to-chunker)
+              (with-handlers ([exn:fail?
+                               (lambda (e)
+                                 ((error-display-handler) (exn-message e) e))])
+                ((response-output bresp) to-chunker))
               (close-output-port to-chunker))))
 
   ;; The client might go away while the response is being generated,

--- a/web-server-test/tests/web-server/e2e/all-e2e-tests.rkt
+++ b/web-server-test/tests/web-server/e2e/all-e2e-tests.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
 (require racket/path
-         racket/port
          racket/tcp
          rackunit)
 

--- a/web-server-test/tests/web-server/e2e/head/server.rkt
+++ b/web-server-test/tests/web-server/e2e/head/server.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+(require web-server/servlet
+         web-server/servlet-dispatch
+         web-server/web-server)
+
+(provide start)
+
+(define (start port)
+  (serve
+   #:port port
+   #:dispatch (dispatch/servlet
+               (lambda (_req)
+                 (response/output
+                  #:headers (list (make-header #"X-Example" #"Found"))
+                  (lambda (out)
+                    (displayln "hello" out)))))))

--- a/web-server-test/tests/web-server/e2e/head/tests.rkt
+++ b/web-server-test/tests/web-server/e2e/head/tests.rkt
@@ -1,0 +1,53 @@
+#lang racket/base
+
+(require racket/tcp
+         rackunit)
+
+(provide make-tests)
+
+(define (make-tests port)
+  ;; net/url and net/http-client both ignore the body of HEAD requests
+  ;; if present so we can't use them to test this.
+  (define (request method path)
+    (define-values (in out)
+      (tcp-connect "127.0.0.1" port))
+
+    (display (format "~a ~a HTTP/1.1\r\n" method path) out)
+    (display "\r\n" out)
+    (close-output-port out)
+
+    (define status (read-line in 'return-linefeed))
+    (define-values (headers body)
+      (for/fold ([headers null]
+                 [headers-done? #f]
+                 [body null]
+                 #:result (values
+                           (reverse headers)
+                           (reverse body)))
+                ([line (in-lines in 'return-linefeed)])
+        (if headers-done?
+            (values headers headers-done? (cons line body))
+            (if (string=? line "")
+                (values headers #t body)
+                (values (cons line headers) #f body)))))
+
+    (values status headers body))
+
+  (test-suite
+   "head"
+
+   (test-case "HEAD requests must not have a body"
+     (define (x-example-header? h)
+       (regexp-match? #px"X-Example" h))
+
+     (define-values (get-status get-headers get-body)
+       (request "GET" "/"))
+     (check-equal? get-status "HTTP/1.1 200 OK")
+     (check-not-false (findf x-example-header? get-headers))
+     (check-equal? get-body '("6" "hello\n" "0" ""))
+
+     (define-values (head-status head-headers head-body)
+       (request "HEAD" "/"))
+     (check-equal? head-status "HTTP/1.1 200 OK")
+     (check-not-false (findf x-example-header? head-headers))
+     (check-equal? head-body '()))))

--- a/web-server-test/tests/web-server/http/response-test.rkt
+++ b/web-server-test/tests/web-server/http/response-test.rkt
@@ -153,7 +153,6 @@
 
      (test-case "connections are closed when responders fail"
        (define responder-thread #f)
-       (define response-out #f)
        (define write-ready (make-semaphore))
        (define resp
          (response/output
@@ -162,7 +161,6 @@
             ;; s.t. raco test --drdr doesn't fail because of it.
             (current-error-port (open-output-nowhere))
             (set! responder-thread (current-thread))
-            (set! response-out out)
             (semaphore-wait write-ready)
             (write-bytes #"a" out)
             (semaphore-wait write-ready)
@@ -176,10 +174,7 @@
            (check-equal? (sync/timeout 1 chunks) #"1\r\na\r\n")
 
            (semaphore-post write-ready)
-           (check-equal? (sync/timeout 1 chunks) #"0\r\n\r\n")
-
-           (check-true (port-closed? response-out))
-           (check-true (thread-dead? responder-thread)))))
+           (check-equal? (sync/timeout 1 chunks) #f))))
 
      (test-case "every chunk resets the rolling 60 second timeout window"
        (define connection #f)

--- a/web-server-test/tests/web-server/http/response-test.rkt
+++ b/web-server-test/tests/web-server/http/response-test.rkt
@@ -165,7 +165,7 @@
             (set! response-out out)
             (semaphore-wait write-ready)
             (write-bytes #"a" out)
-            (flush-output out)
+            (semaphore-wait write-ready)
             (error 'fail))))
 
        (call-with-test-client+server resp
@@ -174,7 +174,10 @@
 
            (semaphore-post write-ready)
            (check-equal? (sync/timeout 1 chunks) #"1\r\na\r\n")
+
+           (semaphore-post write-ready)
            (check-equal? (sync/timeout 1 chunks) #"0\r\n\r\n")
+
            (check-true (port-closed? response-out))
            (check-true (thread-dead? responder-thread)))))
 


### PR DESCRIPTION
Norman Gray pointed out on the [mailing list][1] that responders don't gracefully handle the case where a response's output function throws an exception. Instead of truncating the response, they currently force the connection to hang until it times out or is closed by the client.

This PR "fixes" things so that responses are always terminated regardless of the state of the output function. I also liked @rmculpepper 's idea of intentionally breaking the response by writing a length w/o any follow-up content to make it clear that something went wrong to clients, but I'm not sure if any other web servers do that. I'll take a look at what other servers do tomorrow and report back.

After this change, this code:

```racket
#lang racket/base

(require web-server/http
         web-server/servlet-dispatch
         web-server/web-server)

(define stop
  (serve
   #:port 9111
   #:dispatch (dispatch/servlet
               (lambda (req)
                 (response/output
                  (lambda (out)
                    (displayln "hello" out)
                    (error 'failed)))))))

(with-handlers ([exn:break?
                 (lambda (e)
                   (stop))])
  (sync/enable-break never-evt))
```

Produces responses that look like this to the client:

```
$ telnet 127.1 9111
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET / HTTP/1.1

HTTP/1.1 200 OK
Date: Mon, 25 May 2020 20:35:44 GMT
Last-Modified: Mon, 25 May 2020 20:35:44 GMT
Server: Racket
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked

6
hello

0

GET / HTTP/1.1

HTTP/1.1 200 OK
Date: Mon, 25 May 2020 20:35:51 GMT
Last-Modified: Mon, 25 May 2020 20:35:51 GMT
Server: Racket
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked

6
hello

0
```

[1]: https://groups.google.com/d/msg/racket-users/NgNznbK_n3w/oG3ULVPDAQAJ