### PR TITLE
core: optimize timers, conn handler and responses for throughput under high concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["7.5", "7.6", "current"]
+        racket-version: ["7.6", "7.7", "current"]
         racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -159,8 +159,9 @@
   ;; The client might go away while the response is being generated,
   ;; in which case the output port will be closed so we have to
   ;; gracefully back out when that happens.
-  (with-handlers ([exn:fail? (lambda (e)
-                               (kill-thread to-chunker-t))])
+  (with-handlers ([exn:fail?
+                   (lambda (_)
+                     (kill-thread to-chunker-t))])
     (define buffer (make-bytes 16384))
     (let loop ()
       (define bytes-read-or-eof

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -263,7 +263,7 @@
   (let loop ([k dest-end] [n num])
     (define d (remainder n 10))
     (bytes-set! dest k (+ d 48))  ;; #\0
-    (when (> n 10)
+    (when (>= n 10)
       (loop (sub1 k) (quotient n 10)))))
 
 

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
-(require racket/contract
-         file/md5
+(require file/md5
+         racket/contract
          racket/port
          racket/list
          racket/match
@@ -29,9 +29,10 @@
 (define-simple-macro (define/ext (~and (name:id conn:id arg:formal ...) fun-header)
                        body:expr ...+)
   (define fun-header
-    (with-handlers ([exn:fail? (λ (e)
-                                 (kill-connection! conn)
-                                 (raise e))])
+    (with-handlers ([exn:fail?
+                     (λ (e)
+                       (kill-connection! conn)
+                       (raise e))])
       body ...
       (flush-output (connection-o-port conn)))))
 

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -62,14 +62,13 @@
 (define-syntax (add-missing-headers stx)
   (syntax-parse stx
     [(_ hs:expr [name:bytes value:expr] ...+)
-     #:with to-add-init #'(list name ...)
      #'(let ([res hs])
          (define to-add
-           (for/fold ([to-add to-add-init])
+           (for/fold ([to-add (list name ...)])
                      ([h (in-list hs)])
              (remove (header-field h) to-add bytes-ci=?)))
          (let ([value-e value])
-           (when (and (member name to-add bytes-ci=?) value-e)
+           (when (and value-e (member name to-add bytes-ci=?))
              (set! res (cons (header name value-e) res)))) ...
          res)]))
 

--- a/web-server-lib/web-server/private/connection-manager.rkt
+++ b/web-server-lib/web-server/private/connection-manager.rkt
@@ -2,7 +2,7 @@
 (require racket/contract
          racket/match
          "../safety-limits.rkt"
-         (submod "../safety-limits.rkt" private) 
+         (submod "../safety-limits.rkt" private)
          "timer.rkt")
 
 (provide
@@ -55,7 +55,7 @@
 
 ;; new-connection: connection-manager [number] i-port o-port custodian -> connection
 ;; ask the connection manager for a new connection
-(define new-connection 
+(define new-connection
   (case-lambda
     [(cm i-port o-port cust close?)
      (new-connection cm #f i-port o-port cust close?)]
@@ -74,17 +74,16 @@
       (start-timer tm
                    (or time-to-live initial-timeout)
                    (lambda ()
-                     (cond
-                       [(weak-box-value conn-wb)
-                        => kill-connection-w/o-timer!]))))
+                     (define conn (weak-box-value conn-wb))
+                     (when conn
+                       (kill-connection-w/o-timer! conn)))))
      conn]))
 
 ;; kill-connection!: connection -> void
 ;; kill this connection
 (define (kill-connection! conn)
   #;(printf "K: ~a\n" (connection-id conn))
-  (with-handlers ([exn:fail? void])
-    (cancel-timer! (connection-timer conn)))
+  (cancel-timer! (connection-timer conn))
   (kill-connection-w/o-timer! conn))
 
 (define (kill-connection-w/o-timer! conn)

--- a/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
@@ -141,7 +141,7 @@
     ;; connection will be closed. This shouldn't change any other
     ;; behavior: read-request is already blocking, peeking doesn't
     ;; consume a byte, etc.
-    (define (connection-loop)
+    (let connection-loop ()
       (cond
         [(eof-object? (peek-byte/safe ip))
          (kill-connection! conn)]
@@ -154,8 +154,7 @@
          (config:dispatch conn req)
          (if (connection-close? conn)
              (kill-connection! conn)
-             (connection-loop))]))
-    (connection-loop)))
+             (connection-loop))]))))
 
 (define (peek-byte/safe ip)
   (with-handlers ([exn:fail? (lambda (_) eof)])

--- a/web-server-lib/web-server/test.rkt
+++ b/web-server-lib/web-server/test.rkt
@@ -92,7 +92,7 @@
   (define ip (open-input-bytes ib))
   (define op (open-output-bytes))
   (define tm (start-timer-manager))
-  (values (make-connection 0 (make-timer tm never-evt +inf.0 (lambda () (void)))
+  (values (make-connection 0 (make-timer tm +inf.0 void)
                            ip op (current-custodian) #t)
           ip
           op))

--- a/web-server-test/tests/web-server/http/json.rkt
+++ b/web-server-test/tests/web-server/http/json.rkt
@@ -56,7 +56,7 @@
  (bytes-sort
   (bytes-append
    #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: "
-   (string->bytes/utf-8 (seconds->gmt-string 0))
+   (seconds->gmt-bytes 0)
    #"\r\nServer: Racket\r\nContent-Type: application/json; charset=utf-8\r\nConnection: close\r\n\r\n[\"whoop\",{\"there\":[\"it\",\"is\"]}]"))
 
  ; The default MIME type ("application/json; charset=utf-8")

--- a/web-server-test/tests/web-server/http/response-test.rkt
+++ b/web-server-test/tests/web-server/http/response-test.rkt
@@ -189,7 +189,7 @@
               (loop)))))
 
        (define (ttl)
-         (- (timer-expire-seconds (connection-timer connection))
+         (- (timer-deadline (connection-timer connection))
             (current-inexact-milliseconds)))
 
        (call-with-test-client+server resp

--- a/web-server-test/tests/web-server/http/xexpr.rkt
+++ b/web-server-test/tests/web-server/http/xexpr.rkt
@@ -50,9 +50,9 @@
  (bytes-sort
   (bytes-append
    #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: "
-   (string->bytes/utf-8 (seconds->gmt-string 0))
+   (seconds->gmt-bytes 0)
    #"\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n<a href=\"#\">link</a>"))
- 
+
 
  (write-response tm (response/xexpr '(a ([href "#"]) "link")
                                     #:mime-type #"application/xml"))

--- a/web-server-test/tests/web-server/private/connection-manager-test.rkt
+++ b/web-server-test/tests/web-server/private/connection-manager-test.rkt
@@ -22,7 +22,7 @@
   (define action (timer-action timer))
   (revise-timer!
    timer
-   (max 0 (- (timer-expire-seconds timer)
+   (max 0 (- (timer-deadline timer)
              (current-inexact-milliseconds)))
    (lambda ()
      (dynamic-wind

--- a/web-server-test/tests/web-server/private/request-test.rkt
+++ b/web-server-test/tests/web-server/private/request-test.rkt
@@ -103,7 +103,7 @@
   (parameterize ([current-custodian custodian])
     (define ip (open-input-bytes b))
     (define op (open-output-bytes))
-    (define timer (make-timer tm ip +inf.0 void))
+    (define timer (make-timer tm +inf.0 void))
     (define conn
       (connection 0 timer ip op custodian #f))
 

--- a/web-server-test/tests/web-server/private/response-test.rkt
+++ b/web-server-test/tests/web-server/private/response-test.rkt
@@ -200,7 +200,13 @@
     #"Wed, 01 Apr 1970 12:16:17 GMT")
    (check-equal?
     (seconds->gmt-bytes (+ (* 90 86400) (quotient 86400 2) 10))
-    #"Wed, 01 Apr 1970 12:00:10 GMT")))
+    #"Wed, 01 Apr 1970 12:00:10 GMT")
+   (check-equal?
+    (seconds->gmt-bytes (+ (* 90 86400) (* 13 3600) 20))
+    #"Wed, 01 Apr 1970 13:00:20 GMT")
+   (check-equal?
+    (seconds->gmt-bytes (+ (* 90 86400) (* 13 3600) 620))
+    #"Wed, 01 Apr 1970 13:10:20 GMT")))
 
 (define response-tests
   (test-suite

--- a/web-server-test/tests/web-server/private/response-test.rkt
+++ b/web-server-test/tests/web-server/private/response-test.rkt
@@ -6,6 +6,7 @@
                   make-temporary-file)
          web-server/http
          web-server/http/response
+         (submod web-server/http/response testing)
          (prefix-in compat0: web-server/compat/0/http/response-structs)
          "../util.rkt")
 
@@ -178,20 +179,42 @@
                           #"HEAD")
                   #"HTTP/1.1 200 OK\r\nDate: REDACTED GMT\r\nLast-Modified: REDACTED GMT\r\nServer: Racket\r\nContent-Type: text/html; charset=utf-8\r\n\r\n"))))
 
+(define seconds->gmt-bytes-tests
+  (test-suite
+   "seconds->gmt-bytes"
+
+   (check-equal?
+    (seconds->gmt-bytes 0)
+    #"Thu, 01 Jan 1970 00:00:00 GMT")
+   (check-equal?
+    (seconds->gmt-bytes 86400)
+    #"Fri, 02 Jan 1970 00:00:00 GMT")
+   (check-equal?
+    (seconds->gmt-bytes (+ 86400 3600 193))
+    #"Fri, 02 Jan 1970 01:03:13 GMT")
+   (check-equal?
+    (seconds->gmt-bytes (+ (* 30 86400) 3600 193))
+    #"Sat, 31 Jan 1970 01:03:13 GMT")
+   (check-equal?
+    (seconds->gmt-bytes (+ (* 90 86400) (quotient 86400 2) 977))
+    #"Wed, 01 Apr 1970 12:16:17 GMT")))
+
 (define response-tests
   (test-suite
    "HTTP Responses"
-   
+
    output-response-tests
-   
+
    output-response/method-tests
-   
+
+   seconds->gmt-bytes-tests
+
    (let ()
      (define tmp-file (make-temporary-file))
-     (with-output-to-file tmp-file 
+     (with-output-to-file tmp-file
        (lambda ()
          (display
-          (xexpr->string 
+          (xexpr->string
            `(html (head (title "A title"))
                   (body "Here's some content!")))))
        #:exists 'truncate/replace)

--- a/web-server-test/tests/web-server/private/response-test.rkt
+++ b/web-server-test/tests/web-server/private/response-test.rkt
@@ -197,7 +197,10 @@
     #"Sat, 31 Jan 1970 01:03:13 GMT")
    (check-equal?
     (seconds->gmt-bytes (+ (* 90 86400) (quotient 86400 2) 977))
-    #"Wed, 01 Apr 1970 12:16:17 GMT")))
+    #"Wed, 01 Apr 1970 12:16:17 GMT")
+   (check-equal?
+    (seconds->gmt-bytes (+ (* 90 86400) (quotient 86400 2) 10))
+    #"Wed, 01 Apr 1970 12:00:10 GMT")))
 
 (define response-tests
   (test-suite

--- a/web-server-test/tests/web-server/util.rkt
+++ b/web-server-test/tests/web-server/util.rkt
@@ -54,7 +54,7 @@
   (define ip (open-input-bytes ib))
   (define op (open-output-bytes))
   (define tm (start-timer-manager))
-  (values (make-connection 0 (make-timer tm never-evt +inf.0 (lambda () (void)))
+  (values (make-connection 0 (make-timer tm +inf.0 void)
                            ip op (make-custodian) #t)
           ip
           op))


### PR DESCRIPTION
This change improves the web server's throughput with many (1k+) concurrent connections.  Of the bunch, the most important changes are those to the timer manager and the change to stop peeking in `handle-connection/cm`. I'd recommend looking at the commits individually for readability.

The change to `add-missing-headers` also fixes an issue: previously, the check if a header was already set on the response was case-sensitive.

On my local machine (macOS, 2.4GHz), [this app](https://gist.github.com/Bogdanp/b5ce64066fe6093da7e2ef70c3dab012) performs as follows when 4k requests per second are made for a minute after it's been warmed up:

* master:

```
$ cat targets | vegeta attack -duration=60s -rate 4000/s | vegeta report
Requests      [total, rate, throughput]         240000, 4000.02, 3999.85
Duration      [total, attack, wait]             1m0s, 1m0s, 2.585ms
Latencies     [min, mean, 50, 90, 95, 99, max]  542.112µs, 3.733ms, 3.649ms, 4.776ms, 5.147ms, 5.946ms, 70.843ms
Bytes In      [total, mean]                     1440000, 6.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:240000
Error Set:
```

* this branch:

```
$ cat targets | vegeta attack -duration=60s -rate 4000/s | vegeta report
Requests      [total, rate, throughput]         240000, 4000.02, 4000.00
Duration      [total, attack, wait]             1m0s, 1m0s, 288.141µs
Latencies     [min, mean, 50, 90, 95, 99, max]  174.083µs, 295.654µs, 271.062µs, 381.418µs, 462.48µs, 646.391µs, 5.472ms
Bytes In      [total, mean]                     1440000, 6.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:240000
Error Set:
```

On [one of my servers](https://www.hetzner.com/dedicated-rootserver/ax61-nvme), running the [TechEmpower Benchmarks](https://www.techempower.com/benchmarks) against the two branches (`racket` is running master and `racket-perf` is running this branch) yields:

https://www.techempower.com/benchmarks/#section=test&shareid=669bfab7-9242-4c26-8921-a4fe9ccd8530&hw=ph&test=composite&a=2

The maximum throughput does not increase by much (only about 4k/s in the json and plaintext benchmarks), but take a look at the `Data Table` tab for each test, in particular the plaintext test. Performance now suffers less when there are many concurrent connections.

There are [more changes that could be made](https://gist.githubusercontent.com/Bogdanp/738ea20d7454f527eeb154b03fd9768b/raw/b045f308c590d86530ef6b00ee4082b74bc82948/perf-results.txt), but this is all I had time for this weekend and I think these are some nice gains.