### PR TITLE
ci: update racket versions and pin setup-racket@v1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["7.6", "7.7", "current"]
-        racket-variant: ["regular", "CS"]
+        racket-version: ["8.0", "8.1", "current"]
+        racket-variant: ["BC", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.3
+      - uses: Bogdanp/setup-racket@v1.5
         with:
           architecture: x64
           distribution: full


### PR DESCRIPTION
I noticed in #103 that CI was failing due to some changes to the installer URI scheme so this fixes that problem.