### PR TITLE
New wrapping dispatcher for transforming requests and responses

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -511,3 +511,45 @@ Consider this example:
 
 (do-not-return)
 ]
+
+@; ------------------------------------------------------------
+@section[#:tag "wrap"]{Wrapping Requests & Responses}
+@a-dispatcher[web-server/dispatchers/dispatch-wrap
+              @elem{provides a general-purpose wrapping dispatcher that allows one to intercept an incoming request as well as the response returned by other servlets}]{
+
+@defproc[(make [servlet (-> request? response?)]
+               [req-trans (-> request? request?)]
+               [res-trans (-> response? response?)])
+         dispatcher/c]{
+
+Returns a dispatcher that wraps @racket[res-trans] around
+@racket[servlet], which itself receives requests transformed
+by @racket[req-trans]. Put differently, the servlet
+underlying the dispatcher returned by @racket[make] is
+equivalent to @racket[(λ (r) (res-trans (servlet (req-trans
+r))))].
+
+If you're not interested in transforming requests, pass in
+@racket[identity] (the identity function) for
+@racket[req-trans]. Similarly, using @racket[identity] for
+@racket[res-trans] will cause responses to pass through
+unchanged. (Using @racket[identity] for @emph{both}
+@racket[req-trans] and @racket[res-trans] is equivalent to
+just using @racket[servlet] as-is.)
+
+A typical use case for this dispatcher would be to inject
+headers into requests or responses. Similarly, functionally
+updating existing headers also fits into this pattern. Since
+the entire request -- not just its headers -- is available
+to @racket[req-trans] (and similarly for the response and
+@racket[res-trans]), arbitrary rewriting of request/response
+bodies is possible. Side effects in @racket[req-trans] and
+@racket[res-trans] are permitted as long as @racket[make]'s
+contracts are adhered to.
+
+}
+
+@history[#:changed "1.9"
+         @elem{First version of this dispatcher}]
+
+}

--- a/web-server-lib/web-server/dispatchers/dispatch-wrap.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-wrap.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+(require racket/contract
+         web-server/dispatchers/dispatch
+         web-server/http/request-structs
+         web-server/http/response-structs
+         (prefix-in lift: web-server/dispatchers/dispatch-lift))
+
+(provide/contract
+ [interface-version dispatcher-interface-version/c]
+ [make (-> (-> request? response?)
+           (-> request? request?)
+           (-> response? response?)
+           dispatcher/c)])
+
+(define interface-version 'v1)
+
+(define (make servlet req-trans res-trans)
+  (lift:make (λ (req) (res-trans (servlet (req-trans req))))))

--- a/web-server-test/tests/web-server/dispatchers/all-dispatchers-tests.rkt
+++ b/web-server-test/tests/web-server/dispatchers/all-dispatchers-tests.rkt
@@ -5,6 +5,7 @@
          "dispatch-servlets-test.rkt"
          "dispatch-lang-test.rkt"
          "dispatch-host-test.rkt"
+         "dispatch-wrap-test.rkt"
          "filesystem-map-test.rkt")
 (provide all-dispatchers-tests)
 
@@ -15,5 +16,6 @@
    dispatch-host-tests
    dispatch-files-tests
    dispatch-servlets-tests
+   dispatch-wrap-tests
    dispatch-lang-tests
    filesystem-map-tests))

--- a/web-server-test/tests/web-server/dispatchers/dispatch-wrap-test.rkt
+++ b/web-server-test/tests/web-server/dispatchers/dispatch-wrap-test.rkt
@@ -1,0 +1,88 @@
+#lang racket/base
+
+(require rackunit
+         racket/promise
+         racket/function
+         net/url
+         web-server/http/request-structs
+         web-server/http/response-structs
+         web-server/dispatchers/dispatch
+         web-server/private/connection-manager
+         (prefix-in wrap: web-server/dispatchers/dispatch-wrap)
+         "../util.rkt")
+
+(provide dispatch-wrap-tests)
+
+; request? -> response?
+(define (count-request-headers req)
+  (response 200
+            #"OK"
+            (current-seconds)
+            #f
+            (list (make-header #"Request-Header-Count"
+                               (string->bytes/utf-8
+                                (number->string
+                                 (length (request-headers/raw req))))))
+            (lambda (p) (write-bytes #"hi" p))))
+
+(define (inject-request-header req)
+  (define h (make-header #"Joe" #"Blow"))
+  (struct-copy request
+               req
+               [headers/raw (cons h (request-headers/raw req))]))
+
+(define (replace-response-body res)
+  (struct-copy response
+               res
+               [output (lambda (p)
+                         (write-bytes #"Intercepted!" p))]))
+
+(define dummy-request
+  (request #"POST"
+           (string->url "whatever")
+           (list (make-header #"Vary" #"Lisp"))
+           (delay (list))
+           #f
+           "localhost"
+           80
+           "whatever"))
+
+(define dispatch-wrap-tests
+  (test-suite
+   "Wrap"
+
+   (test-case
+       "Transform neither request nor response"
+     (let ([d (wrap:make count-request-headers identity identity)]
+           [c (fake-connection-for-bytes #"")])
+       (d c dummy-request)
+       (define bs (bytes->string/utf-8 (get-output-bytes (connection-o-port c))))
+       (check-regexp-match #px"\r\nRequest-Header-Count: 1\r\n" bs bs)
+       (check-regexp-match #px"\r\n\r\nhi$" bs bs)))
+
+   (test-case
+       "Transform request, do nothing to response"
+     (let ([d (wrap:make count-request-headers inject-request-header identity)]
+           [c (fake-connection-for-bytes #"")])
+       (d c dummy-request)
+       (define bs (bytes->string/utf-8 (get-output-bytes (connection-o-port c))))
+       (check-regexp-match #px"\r\nRequest-Header-Count: 2\r\n" bs bs)
+       (check-regexp-match #px"\r\n\r\nhi$" bs bs)))
+
+   (test-case
+       "Transform response, do nothing to request"
+     (let ([d (wrap:make count-request-headers identity replace-response-body)]
+           [c (fake-connection-for-bytes #"")])
+       (d c dummy-request)
+       (define bs (bytes->string/utf-8 (get-output-bytes (connection-o-port c))))
+       (check-regexp-match #px"\r\nRequest-Header-Count: 1\r\n" bs bs)
+       (check-regexp-match #px"\r\n\r\nIntercepted!$" bs bs)))
+
+   (test-case
+       "Transform both request and response"
+     (let ([d (wrap:make count-request-headers inject-request-header replace-response-body)]
+           [c (fake-connection-for-bytes #"")])
+       (d c dummy-request)
+       (define bs (bytes->string/utf-8 (get-output-bytes (connection-o-port c))))
+       (check-regexp-match #px"\r\nRequest-Header-Count: 2\r\n" bs bs)
+       (check-regexp-match #px"\r\n\r\nIntercepted!$" bs bs)))))


### PR DESCRIPTION
A common pattern in web development is adding layers of request and response wrapping. That is, a web app often doesn't handle the original incoming request that hit the web server. Rather, it handles an enriched or otherwise transformed request. Similarly, the final response that ultimately gets serialized over the network may not be the response that the app emitted (after any initial request request transformations). As with requests, the final response may be the result of a chain of transformations.

As an example of all this, consider the task of injecting headers. Headers may be added (or changed, or dropped) from a request to store computed values that are needed further down the line. Authentication, for example, or processing cookies fits this pattern.

Another class of examples concerns bodies. Request and response bodies may be similarly intercepted. A response body, for example, might be parsed so that and obscenities or sensitive information can be filtered out. Cookies may be set.

Here we define a new kind of dispatcher that encapsulates this wrapping pattern. Given a servlet (that is, a function from `request?` to `response?`), a request transformer (`request? . -> . request?`) and a response transformer (`response? . -> . response?`), a `dispatcher/c` is created that passes the servlet the transformed request, and transforms the response returned by the servlet.

Note that in the documentation there's a reference to version 1.9. That's the same version that introduced the ability to set caching-related headers in the files dispatcher. It seems excessive to me to bump the version again, to 1.10, just for this change. In my view these two changes could be bundled together for the 1.9 release.