### PR TITLE
Fix contract for `response/output`

### DIFF
--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -90,7 +90,7 @@
  [response/full (-> response-code/c (or/c #f bytes?) real? (or/c #f bytes?) (listof header?) (listof bytes?) response?)]
  [response/output (->* ((-> output-port? any))
                        (#:code response-code/c
-                        #:message bytes?
+                        #:message (or/c bytes? #f)
                         #:seconds real?
                         #:mime-type (or/c bytes? #f)
                         #:headers (listof header?))


### PR DESCRIPTION
The contract was overly strict. The intention all along was
to allow `#f` as the `#:message` argument. That's what's in
the docs, and indeed, we use `#f` in some tests.

closes #111 