### PR TITLE
Bump version

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -418,13 +418,13 @@ Creates a denied procedure from an authorized procedure.
  application.}
 
 @history[
-  #:changed "1.9"
-  @elem{Support a number of options for setting a @tt{Cache-Control} response header}
   #:changed "1.7"
   @elem{Support for non-{GET,HEAD} requests.}
   #:changed "1.7"
   @elem{Treat unreadable files as non-existing files.}
   #:changed "1.9"
+  @elem{Support a number of options for setting a @tt{Cache-Control} response header}
+  #:changed "1.10"
   @elem{Support @racket[#:path->headers].}
 ]
 

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -15,7 +15,7 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.9")
+(define version "1.10")
 
 (define license
   '(Apache-2.0 OR MIT))


### PR DESCRIPTION
The previous PR (#117) should have bumped a version,
so that users who want to use #:path->headers can indicate
the version lower bound.