### PR TITLE
more optimizations

### DIFF
--- a/web-server-doc/web-server/scribblings/safety-limits.scrbl
+++ b/web-server-doc/web-server/scribblings/safety-limits.scrbl
@@ -22,7 +22,7 @@
 @deftogether[
  (@defproc[(safety-limits? [v any/c]) boolean?]
    @defproc[(make-safety-limits
-             [#:max-concurrent max-concurrent positive-count/c 1000]
+             [#:max-concurrent max-concurrent positive-count/c 10000]
              [#:max-waiting max-waiting exact-nonnegative-integer? 511]
              [#:request-read-timeout request-read-timeout timeout/c 60]
              [#:max-request-line-length max-request-line-length nonnegative-length/c

--- a/web-server-doc/web-server/scribblings/safety-limits.scrbl
+++ b/web-server-doc/web-server/scribblings/safety-limits.scrbl
@@ -22,6 +22,7 @@
 @deftogether[
  (@defproc[(safety-limits? [v any/c]) boolean?]
    @defproc[(make-safety-limits
+             [#:max-concurrent max-concurrent positive-count/c 1000]
              [#:max-waiting max-waiting exact-nonnegative-integer? 511]
              [#:request-read-timeout request-read-timeout timeout/c 60]
              [#:max-request-line-length max-request-line-length nonnegative-length/c
@@ -60,6 +61,11 @@
 
  The arguments to @racket[make-safety-limits] are used as follows:
  @itemlist[
+ @item{The @racket[max-concurrent] argument limits the number of open
+   concurrent connections to the server.  Once the limit is reached, new
+   connections are queued at the TCP level (see @racket[max-waiting])
+   until existing connections finish or time out.
+   }
  @item{The @racket[max-waiting] argument is passed to @racket[tcp-listen]
    to specify the maximum number of client connections that can be waiting for acceptance.
    When @racket[max-waiting] clients are waiting for acceptance, no new client connections can be made.
@@ -101,7 +107,7 @@
    @tt{multipart/form-data} (file upload) requests by the standard
    @sigelem[dispatch-server-config*^ read-request]
    implementation (e.g. from @racket[serve] or @racket[web-server@]).
-   
+
    The number of files and non-file ``fields'' per request are limited by
    @racket[max-form-data-files] and @racket[max-form-data-fields], respectively,
    and @racket[max-form-data-file-length] and @racket[max-form-data-field-length]
@@ -109,7 +115,7 @@
    Additionally, the total number of ``parts,'' which includes both files and fields,
    must not exceed @racket[max-form-data-parts].
    Requests that exceed these limits are rejected.
-   
+
    Files longer than @racket[request-file-memory-threshold], in bytes,
    are automatically offloaded to disk as temporary files
    to avoid running out of memory.
@@ -163,18 +169,19 @@
  and optional arguments to functions like @racket[serve]:
  if values weren't explicitly supplied, the default behavior was closest to using
  @racket[(make-unlimited-safety-limits #:request-read-timeout 60)].
- 
+
  However, version 1.6 adopted @racket[(make-safety-limits)] as the default,
  as most applications would benefit from using reasonable protections.
  When porting from earlier versions of this library,
  if you think your application may be especially resource-intensive,
  you may prefer to use @racket[make-unlimited-safety-limits] while determining
  limits that work for your application.
-     
+
  @history[#:added "1.6"]
 }
 
 @defproc[(make-unlimited-safety-limits
+          [#:max-concurrent max-concurrent positive-count/c +inf.0]
           [#:max-waiting max-waiting exact-nonnegative-integer? 511]
           [#:request-read-timeout request-read-timeout timeout/c +inf.0]
           [#:max-request-line-length max-request-line-length nonnegative-length/c +inf.0]
@@ -204,6 +211,6 @@
 
  Note that the default value for @racket[max-waiting] is @racket[511],
  @italic{not} @racket[+inf.0], due to the contract of @racket[tcp-listen].
-      
+
  @history[#:added "1.6"]
 }

--- a/web-server-doc/web-server/scribblings/safety-limits.scrbl
+++ b/web-server-doc/web-server/scribblings/safety-limits.scrbl
@@ -49,6 +49,8 @@
             safety-limits?]
    @defthing[nonnegative-length/c flat-contract?
              #:value (or/c exact-nonnegative-integer? +inf.0)]
+   @defthing[positive-count/c flat-contract?
+             #:value (or/c exact-positive-integer? +inf.0)]
    @defthing[timeout/c flat-contract?
              #:value (>=/c 0)])]{
  The web server uses opaque @deftech{safety limits} values, recognized
@@ -178,6 +180,7 @@
  limits that work for your application.
 
  @history[#:added "1.6"]
+ @history[#:changed "1.11" @elem{added the @racket[max-concurrent] limit}]
 }
 
 @defproc[(make-unlimited-safety-limits
@@ -213,4 +216,5 @@
  @italic{not} @racket[+inf.0], due to the contract of @racket[tcp-listen].
 
  @history[#:added "1.6"]
+ @history[#:changed "1.11" @elem{added the @racket[max-concurrent] limit}]
 }

--- a/web-server-lib/info.rkt
+++ b/web-server-lib/info.rkt
@@ -6,7 +6,6 @@
                ("base" #:version "7.4.0.5")
                "net-lib"
                "net-cookies-lib"
-               "compatibility-lib"
                "scribble-text-lib"
                "parser-tools-lib"))
 (define build-deps '("rackunit-lib"))
@@ -15,7 +14,7 @@
 
 (define pkg-authors '(jay))
 
-(define version "1.10")
+(define version "1.11")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/web-server-lib/web-server/http/request.rkt
+++ b/web-server-lib/web-server/http/request.rkt
@@ -8,7 +8,7 @@
          racket/match
          racket/port
          racket/promise
-         web-server/http/request-structs
+         (submod web-server/http/request-structs private)
          web-server/safety-limits
          (submod web-server/safety-limits private)
          web-server/private/connection-manager
@@ -116,8 +116,9 @@
       (read-bindings&post-data/raw data-ip method uri headers
                                    #:safety-limits limits))
     (define request
-      (make-request method uri headers bindings/raw-promise raw-post-data
-                    host-ip host-port client-ip))
+      (make-request
+       method uri headers bindings/raw-promise raw-post-data
+       host-ip host-port client-ip))
     (define close?
       (or connection-close?
           (close-connection? headers major minor
@@ -370,8 +371,9 @@
          [(list-rest k v)
           (and (symbol? k)
                (string? v)
-               (make-binding:form (string->bytes/utf-8 (symbol->string k))
-                                  (string->bytes/utf-8 v)))])
+               (binding:form
+                (string->bytes/utf-8 (symbol->string k))
+                (string->bytes/utf-8 v)))])
        (url-query uri))))
 
   (define (read-data who proc)
@@ -429,8 +431,9 @@
                       "Couldn't extract form field name for file upload")]
 
                     [(#f (list _ _ f0 f1))
-                     (make-binding:form (or f0 f1)
-                                        (port->bytes contents))]
+                     (binding:form
+                      (or f0 f1)
+                      (port->bytes contents))]
 
                     [((list _ _ f00 f01) (list _ _ f10 f11))
                      (make-binding:file/port (or f10 f11)
@@ -477,20 +480,16 @@
              [#f
               ;; skip the & or do nothing on #<eof>
               (read-byte in)
-              (loop (cons (make-binding:form (urldecode key) #"")
-                          bindings))]
+              (loop (cons (binding:form (urldecode key) #"") bindings))]
 
              ;; k=...&...
              [(list _ value _)
-              (loop (cons (make-binding:form (urldecode key)
-                                             (urldecode value))
-                          bindings))])]
+              (loop (cons (binding:form (urldecode key) (urldecode value)) bindings))])]
 
           ;; k
           ;; k&
           [(list _ key (or #"" #"&"))
-           (loop (cons (make-binding:form (urldecode key) #"")
-                       bindings))]
+           (loop (cons (binding:form (urldecode key) #"") bindings))]
 
           ;; #<eof>
           [#f

--- a/web-server-lib/web-server/http/request.rkt
+++ b/web-server-lib/web-server/http/request.rkt
@@ -93,7 +93,7 @@
                  #:max-request-body-length max-request-body-length)
     limits)
 
-  (define (do-read-request conn host-port port-addresses)
+  (lambda (conn host-port port-addresses)
     (reset-connection-timeout! conn read-timeout)
     (define ip (connection-i-port conn))
     (define-values (method uri major minor)
@@ -120,16 +120,7 @@
       (or connection-close?
           (close-connection? headers major minor
                              client-ip host-ip)))
-    (values request close?))
-
-  (define (read-request conn host-port port-addresses)
-    (with-handlers ([exn:fail?
-                     (λ (exn)
-                       (kill-connection! conn)
-                       (raise exn))])
-      (do-read-request conn host-port port-addresses)))
-
-  read-request)
+    (values request close?)))
 
 (define read-request
   (make-read-request))

--- a/web-server-lib/web-server/http/request.rkt
+++ b/web-server-lib/web-server/http/request.rkt
@@ -68,6 +68,8 @@
                      (#:safety-limits safety-limits?)
                      (listof header?))]))
 
+(module+ private
+  (provide make-read-request))
 
 (module* internal-test #f
   (provide read-http-line/limited

--- a/web-server-lib/web-server/http/response-structs.rkt
+++ b/web-server-lib/web-server/http/response-structs.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
 (require racket/contract
-         racket/match
          web-server/http/request-structs
          "status-code.rkt")
 
@@ -97,3 +96,6 @@
                        response?)]
  [TEXT/HTML-MIME-TYPE bytes?]
  [APPLICATION/JSON-MIME-TYPE bytes?])
+
+(module+ private
+  (provide (struct-out response)))

--- a/web-server-lib/web-server/http/response.rkt
+++ b/web-server-lib/web-server/http/response.rkt
@@ -7,8 +7,8 @@
          racket/match
          web-server/private/connection-manager
          (submod web-server/private/connection-manager private)
-         web-server/http/request-structs
-         web-server/http/response-structs
+         (submod web-server/http/request-structs private)
+         (submod web-server/http/response-structs private)
          web-server/private/util
          syntax/parse/define
          (for-syntax racket/base

--- a/web-server-lib/web-server/private/dispatch-server-sig.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-sig.rkt
@@ -1,11 +1,11 @@
 #lang racket/base
 
-(require racket/unit
+(require racket/async-channel
          racket/contract
-         racket/async-channel
-         "../safety-limits.rkt"
+         racket/unit
+         web-server/private/connection-manager
          web-server/private/util
-         web-server/private/connection-manager)
+         web-server/safety-limits)
 
 (define-signature dispatch-server^
   ((contracted

--- a/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
@@ -142,7 +142,7 @@
                    (lambda (e)
                      (unless (exn-expected? e)
                        ((error-display-handler)
-                        (format "Connection error:" (exn-message e))
+                        (format "Connection error: ~a" (exn-message e))
                         e))
                      (kill-connection! conn))])
     (let connection-loop ()

--- a/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
@@ -58,7 +58,7 @@
              ;; exist implementations where it isn't.  For backwards
              ;; compatibility, use `always-evt' when the listener is
              ;; not synchronizable.
-             (define listener-evt (if (evt? listener) listener always-evt))
+             (define listener-evt (if (evt? listener) listener (handle-evt always-evt (λ (_) listener))))
              (define max-concurrent (safety-limits-max-concurrent config:safety-limits))
              (let loop ([in-progress 0])
                (loop

--- a/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
+++ b/web-server-lib/web-server/private/dispatch-server-with-connect-unit.rkt
@@ -138,8 +138,12 @@
   (define conn
     (new-connection cm ip op (current-custodian) #f))
 
-  (with-handlers ([exn-expected?
-                   (lambda (_)
+  (with-handlers ([exn:fail?
+                   (lambda (e)
+                     (unless (exn-expected? e)
+                       ((error-display-handler)
+                        (format "Connection error:" (exn-message e))
+                        e))
                      (kill-connection! conn))])
     (let connection-loop ()
       (define-values (req close?)

--- a/web-server-lib/web-server/safety-limits.rkt
+++ b/web-server-lib/web-server/safety-limits.rkt
@@ -10,6 +10,7 @@
 ;; a private submodule providing accessor functions and a match expander.
 (provide timeout/c
          nonnegative-length/c
+         positive-count/c
          safety-limits?
          (contract-out
           [make-safety-limits make-safety-limits/c]
@@ -22,6 +23,9 @@
 
 (define/final-prop nonnegative-length/c
   (or/c exact-nonnegative-integer? +inf.0))
+
+(define/final-prop positive-count/c
+  (or/c exact-positive-integer? +inf.0))
 
 (define-syntax-parser define-safety-limits/private-submodule
   [(_ (~seq field:id contract:expr default:expr (~optional (~seq #:unlimited unlimited:expr)))
@@ -65,6 +69,7 @@
 
 
 (define-safety-limits/private-submodule
+  max-concurrent positive-count/c 1000 #:unlimited +inf.0
   max-waiting exact-nonnegative-integer? 511 #:unlimited 511 ;; contract from tcp-listen
   request-read-timeout timeout/c 60
   max-request-line-length nonnegative-length/c (* 8 1024)
@@ -80,4 +85,3 @@
   max-form-data-header-length nonnegative-length/c (* 8 1024)
   response-timeout timeout/c 60
   response-send-timeout timeout/c 60)
-

--- a/web-server-lib/web-server/safety-limits.rkt
+++ b/web-server-lib/web-server/safety-limits.rkt
@@ -14,8 +14,7 @@
          safety-limits?
          (contract-out
           [make-safety-limits make-safety-limits/c]
-          [make-unlimited-safety-limits make-safety-limits/c]
-          ))
+          [make-unlimited-safety-limits make-safety-limits/c]))
 
 (define/final-prop timeout/c
   ;; requires a nonnegative real that is not +nan.0
@@ -69,7 +68,7 @@
 
 
 (define-safety-limits/private-submodule
-  max-concurrent positive-count/c 1000 #:unlimited +inf.0
+  max-concurrent positive-count/c 10000 #:unlimited +inf.0
   max-waiting exact-nonnegative-integer? 511 #:unlimited 511 ;; contract from tcp-listen
   request-read-timeout timeout/c 60
   max-request-line-length nonnegative-length/c (* 8 1024)

--- a/web-server-lib/web-server/web-server.rkt
+++ b/web-server-lib/web-server/web-server.rkt
@@ -18,6 +18,7 @@
          web-server/web-server-sig
          web-server/web-server-unit
          (prefix-in http: web-server/http/request)
+         (prefix-in http/private: (submod web-server/http/request private))
          (prefix-in http: web-server/http/response))
 
 (provide/contract
@@ -99,7 +100,7 @@
                                          #:max-waiting _max-waiting
                                          #:request-read-timeout _timeout)])
   (define read-request
-    (http:make-read-request
+    (http/private:make-read-request
      #:connection-close? connection-close?
      #:safety-limits safety-limits))
   (define-unit-binding a-dispatch-server-connect@

--- a/web-server-test/tests/web-server/e2e/max-concurrent/server.rkt
+++ b/web-server-test/tests/web-server/e2e/max-concurrent/server.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+
+(require web-server/safety-limits
+         web-server/servlet
+         web-server/servlet-dispatch
+         web-server/web-server)
+
+(provide start)
+
+(define (app _req)
+  (response/output
+   (lambda (out)
+     (display "ok" out))))
+
+(define (start port)
+  (serve
+   #:port port
+   #:dispatch (dispatch/servlet app)
+   #:safety-limits (make-safety-limits
+                    #:max-concurrent 1
+                    #:max-waiting 10)))

--- a/web-server-test/tests/web-server/e2e/max-concurrent/tests.rkt
+++ b/web-server-test/tests/web-server/e2e/max-concurrent/tests.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+(require net/http-client
+         racket/match
+         racket/port
+         rackunit)
+
+(provide make-tests)
+
+(define (make-tests port)
+  (define-check (check-concurrent-requests n min-successes min-failures)
+    (let ([sema (make-semaphore)])
+      (define result-ch (make-channel))
+      (define thds
+        (for/list ([_ (in-range n)])
+          (thread
+           (lambda ()
+             (with-handlers ([(λ (_) #t)
+                              (λ (e) (channel-put result-ch e))])
+               (define conn (http-conn-open "127.0.0.1" #:port port))
+               (semaphore-wait sema)
+               (define-values (line _headers in)
+                 (http-conn-sendrecv! conn "/"))
+               (channel-put result-ch (list line (port->string in)))
+               (http-conn-abandon! conn))))))
+      (sync (system-idle-evt))
+      (for ([_ (in-list thds)])
+        (semaphore-post sema))
+      (define successes
+        (for/sum ([_ (in-list thds)])
+          (match (sync result-ch)
+            [(? exn?) 0]
+            ['(#"HTTP/1.1 200 OK" "ok") 1]
+            [_ 0])))
+      (when (< successes min-successes)
+        (fail (format "expected at least ~a successes but got ~a" min-successes successes)))
+      (define failures (- n successes))
+      (when (< failures min-failures)
+        (fail (format "expected at least ~a failures but got ~a" min-failures failures)))))
+
+  (test-suite
+   "max-concurrent"
+
+   (test-suite
+    "sequential requests"
+    (for ([_ (in-range 10)])
+      (define-values (_line _headers in)
+        (http-sendrecv "127.0.0.1" #:port port "/"))
+      (check-equal? (port->string in) "ok")))
+
+   (test-suite
+    "concurrent requests"
+
+    (check-concurrent-requests 10 10 0)
+    ;(check-concurrent-requests 500 10 1)  times out in GitHub Actions
+    )))

--- a/web-server-test/tests/web-server/pr/12658.rkt
+++ b/web-server-test/tests/web-server/pr/12658.rkt
@@ -3,8 +3,8 @@
          "12658-mod.rkt")
 
 (check-exn
- exn:fail:contract:arity?
- (lambda () (go 42))
- #rx"go: arity mismatch;\n the expected number of arguments does not match the given number\n  expected: 0\n  given: 1")
-
-
+ (lambda (e)
+   (and (exn:fail:contract:arity? e)
+        (regexp-match? #rx"go: arity mismatch;\n the expected number of arguments does not match the given number\n  expected: 0\n  given: 1"
+                       (exn-message e))))
+ (lambda () (go 42)))

--- a/web-server-test/tests/web-server/private/request-test.rkt
+++ b/web-server-test/tests/web-server/private/request-test.rkt
@@ -269,12 +269,25 @@
 ;
 ;
 
+(define (bytes->nonnegative-integer-suite base)
+  (test-suite
+   (~a "base " base)
+
+   (check-false (bytes->nonnegative-integer #"" base))
+   (check-false (bytes->nonnegative-integer #"-123" base))
+   (check-false (bytes->nonnegative-integer #"$!#$W" base))
+   (for ([i (in-range #xFFFF)])
+     (check-equal? i (bytes->nonnegative-integer (string->bytes/utf-8 (number->string i base)) base)))))
+
 (define request-tests
   (test-suite
    "HTTP Requests"
 
    (test-suite
     "Utilities"
+
+    (bytes->nonnegative-integer-suite 10)
+    (bytes->nonnegative-integer-suite 16)
 
     (test-suite
      "read-http-line/limited"

--- a/web-server-test/tests/web-server/private/request-test.rkt
+++ b/web-server-test/tests/web-server/private/request-test.rkt
@@ -286,8 +286,11 @@
    (test-suite
     "Utilities"
 
-    (bytes->nonnegative-integer-suite 10)
-    (bytes->nonnegative-integer-suite 16)
+    (test-suite
+     "bytes->nonnegative-integer-suite"
+
+     (bytes->nonnegative-integer-suite 10)
+     (bytes->nonnegative-integer-suite 16))
 
     (test-suite
      "read-http-line/limited"


### PR DESCRIPTION
I'm opening this as a draft in case folks want to weigh in on the changes. I've still got a few changes I want to make over the next couple weeks so this isn't quite ready yet. This PR includes the commit from #120, but that can be merged independently so it doesn't block #119.

The PR may be easier to read if you read the commits independently. I forgot @samth also worked on removing `run-server` until I looked at the list of open PRs just now, but I took that a little further by also improving the server loop in a couple ways so I think this PR supersedes #106.

Tested against the `/plaintext` endpoint of [this app](https://github.com/Bogdanp/FrameworkBenchmarks/blob/87870c5c1d746e8c253fdd3bf03e18eec4dafc69/frameworks/Racket/racket/app.rkt). Master branch:

```
Requests      [total, rate, throughput]         30000, 1000.04, 1000.03
Duration      [total, attack, wait]             29.999s, 29.999s, 286.417µs
Latencies     [min, mean, 50, 90, 95, 99, max]  229.205µs, 318.265µs, 293.078µs, 367.174µs, 393.675µs, 606.119µs, 14.015ms
Bytes In      [total, mean]                     390000, 13.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:30000  
Error Set:
```

(note that this app uses its own [dispatcher](https://github.com/Bogdanp/FrameworkBenchmarks/blob/87870c5c1d746e8c253fdd3bf03e18eec4dafc69/frameworks/Racket/racket/app.rkt#L217-L218), not `dispatch/servlet`, which is why these numbers are better than the baseline numbers in commit 4506e7290b30d4387f6c63a0f8c95b97782fecab -- `dispatch/servlet` needs to do a lot of work that applications that don't use continuations don't benefit from)

This branch:

```
Requests      [total, rate, throughput]         30000, 1000.04, 1000.03
Duration      [total, attack, wait]             29.999s, 29.999s, 262.316µs
Latencies     [min, mean, 50, 90, 95, 99, max]  197.619µs, 253.639µs, 248.664µs, 280.93µs, 297.689µs, 344.797µs, 929.773µs
Bytes In      [total, mean]                     390000, 13.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:30000
Error Set:
```

For comparison, here's how Node 17 running express does on the same benchmark on my machine:

```
Requests      [total, rate, throughput]         30000, 1000.03, 1000.03
Duration      [total, attack, wait]             29.999s, 29.999s, 182.925µs
Latencies     [min, mean, 50, 90, 95, 99, max]  136.996µs, 190.037µs, 185.03µs, 208.014µs, 219.565µs, 303.124µs, 1.406ms
Bytes In      [total, mean]                     390000, 13.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:30000
Error Set:
```