### PR TITLE
Add Combined Log Format option

### DIFF
--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -243,15 +243,22 @@ a URL that refreshes the password file, servlet cache, etc.}
  to @litchar{-}.
 }
 
+@defthing[combined-log-format format-reqresp/c]{
+ Formats a request and a response to approximate the Common Log Format.
+ As this function does not have access to the size of the object returned
+ to the client, it defaults the field to @litchar{-}.
+}
+
 @defthing[log-format/c contract?]{
- Equivalent to @racket[(symbols 'parenthesized-default 'extended 'apache-default)].
+ Equivalent to @racket[(symbols 'parenthesized-default 'extended 'apache-default 'combined)].
 }
 
 @defproc[(log-format->format [id log-format/c])
          format-reqresp/c]{
  Maps @racket['parenthesized-default] to @racket[paren-format],
- @racket['extended] to @racket[extended-format], and
- @racket['apache-default] to @racket[apache-default-format].
+ @racket['extended] to @racket[extended-format],
+ @racket['apache-default] to @racket[apache-default-format], and
+ @racket['combined] to @racket[combined-log-format]
 }
 
 @defproc[(make [#:format format (or/c log-format/c format-reqresp/c) paren-format]
@@ -292,18 +299,24 @@ a URL that refreshes the password file, servlet cache, etc.}
  includes information about the response to a request, which this
  function does not have access to, so it defaults the last two fields
  to @litchar{-} and @litchar{-}.
+}
 
+@defthing[combined-log-format format-req/c]{
+ Formats a request and a response to approximate the Common Log Format.
+ As this function does not have access to the size of the object returned
+ to the client, it defaults the field to @litchar{-}.
 }
 
 @defthing[log-format/c contract?]{
- Equivalent to @racket[(symbols 'parenthesized-default 'extended 'apache-default)].
+ Equivalent to @racket[(symbols 'parenthesized-default 'extended 'apache-default 'combined)].
 }
 
 @defproc[(log-format->format [id log-format/c])
          format-req/c]{
  Maps @racket['parenthesized-default] to @racket[paren-format],
- @racket['extended] to @racket[extended-format], and
- @racket['apache-default] to @racket[apache-default-format].
+ @racket['extended] to @racket[extended-format],
+ @racket['apache-default] to @racket[apache-default-format], and
+ @racket['combined] to @racket[combined-log-format]
 }
 
 @defproc[(make [#:format format (or/c log-format/c format-req/c) paren-format]

--- a/web-server-doc/web-server/scribblings/dispatchers.scrbl
+++ b/web-server-doc/web-server/scribblings/dispatchers.scrbl
@@ -244,7 +244,7 @@ a URL that refreshes the password file, servlet cache, etc.}
 }
 
 @defthing[combined-log-format format-reqresp/c]{
- Formats a request and a response to approximate the Common Log Format.
+ Formats a request and a response to approximate the Combined Log Format.
  As this function does not have access to the size of the object returned
  to the client, it defaults the field to @litchar{-}.
 }
@@ -302,7 +302,7 @@ a URL that refreshes the password file, servlet cache, etc.}
 }
 
 @defthing[combined-log-format format-req/c]{
- Formats a request and a response to approximate the Common Log Format.
+ Formats a request and a response to approximate the Combined Log Format.
  As this function does not have access to the size of the object returned
  to the client, it defaults the field to @litchar{-}.
 }

--- a/web-server-lib/web-server/dispatchers/dispatch-logresp.rkt
+++ b/web-server-lib/web-server/dispatchers/dispatch-logresp.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require racket/contract
+         racket/list
          web-server/dispatchers/dispatch
          web-server/http
          web-server/http/response
@@ -18,6 +19,7 @@
  [paren-format format-reqresp/c]
  [extended-format format-reqresp/c]
  [apache-default-format format-reqresp/c]
+ [combined-log-format format-reqresp/c]
  [interface-version dispatcher-interface-version/c]
  [make (->* (dispatcher/c)
             (#:format (or/c log-format/c format-reqresp/c)
@@ -57,13 +59,23 @@
     [(extended)
      extended-format]
     [(apache-default)
-     apache-default-format]))
+     apache-default-format]
+    [(combined)
+     combined-log-format]))
 
 (define apache-default-format
   (make-format "~a - - [~a] \"~a\" ~a -\n"
                (λ (req resp)
                  (append (apache-default-format/obj req)
                          (list (response-code resp))))))
+
+(define combined-log-format
+  (make-format "~a - - [~a] \"~a\" ~a - ~a ~a\n"
+               (λ (req resp)
+                 (define request-data (combined-log-format/obj req))
+                 (append (take request-data 3)
+                         (list (response-code resp))
+                         (drop request-data 3)))))
 
 (define paren-format
   (make-format "~s\n"

--- a/web-server-lib/web-server/dispatchers/private/log.rkt
+++ b/web-server-lib/web-server/dispatchers/private/log.rkt
@@ -7,7 +7,7 @@
 (require racket/path
          racket/contract)
 
-(define log-format/c (symbols 'parenthesized-default 'extended 'apache-default))
+(define log-format/c (symbols 'parenthesized-default 'extended 'apache-default 'combined))
 
 (define (make-log-message log-path-or-port formatter)
   (define path (if (output-port? log-path-or-port) #f log-path-or-port))


### PR DESCRIPTION
The Combined Log Format adds "Referer" and "User-Agent" fields to the Apache default log format.

Compliance with the Combined Log Format definition is not 100%, as the size of the object returned to the client is missing, but this caveat is duly pointed out in the added docs.

Thanks for your work on Racket’s web server!