### PR TITLE
Update continue.scrbl

### DIFF
--- a/web-server-doc/web-server/scribblings/tutorial/continue.scrbl
+++ b/web-server-doc/web-server/scribblings/tutorial/continue.scrbl
@@ -1439,7 +1439,7 @@ Finally, here are instructions for using the server in HTTPS mode.
 This requires an SSL certificate and a private key.  It is also very
 platform-specific, but here are the details for using OpenSSL on UNIX:
 
-@commandline{openssl genrsa -des3 -out private-key.pem 1024}
+@commandline{openssl genrsa -des3 -out private-key.pem 2048}
 
 This will generate a new private key, but with a passphrase, which you
 can remove as follows:


### PR DESCRIPTION
A key of size `1024` is no longer considered long enough to be secure. Running the line `plt-web-server --ssl` throws the following error on recent versions:

`ssl-load-certificate-chain!: load failed from: #<path:/myPath/Racket/server-cert.pem> (error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small)`

Bumping the size up to `2048` fixes the error.

---
Kudos on the excellent tutorial. I walked through every line, and this was the only issue I ran into.