### PR TITLE
docs: link to wrapped make-cookie

### DIFF
--- a/web-server-doc/web-server/scribblings/http.scrbl
+++ b/web-server-doc/web-server/scribblings/http.scrbl
@@ -454,6 +454,13 @@ transmission that the server @bold{will not catch}.}
                      web-server/http/response-structs
                      web-server/http/cookie))
 
+@(begin
+   (define-syntax-rule (define-from-net/cookies/server name export)
+     (begin
+       (require (for-label net/cookies/server))
+       (define name @racket[export])))
+   (define-from-net/cookies/server net:make-cookie make-cookie))
+
 @(define rfc6265
    (hyperlink "https://tools.ietf.org/html/rfc6265.html"
               "RFC 6265"))
@@ -474,7 +481,7 @@ transmission that the server @bold{will not catch}.}
           cookie?]{
    Constructs a cookie with the appropriate fields.
 
-   This is a wrapper around @racket[make-cookie] from @racketmodname[net/cookies/server]
+   This is a wrapper around @|net:make-cookie| from @racketmodname[net/cookies/server]
    for backwards compatibility. The @racket[comment] argument is ignored.
    If @racket[expires] is given as a string, it should match
    @link["https://tools.ietf.org/html/rfc7231#section-7.1.1.2"]{RFC 7231, Section 7.1.1.2},


### PR DESCRIPTION
This greatly aids traversing the documentation: readers of this module's make-cookie can now jump to the documentation of the wrapped function instead of jumping to net/cookies/server and scrolling or searching.

The only downside is that the link will display as "net:make-cookie" instead of "make-cookie"; see the GUI Easy documentation [1] as an example (e.g., "gui:dc<%>" in "Custom Views"). In that document, all racket/gui exports are prefixed with gui: to avoid ambiguity, and the links take you to the correct place within racket/gui documentation. That is accomplished by

    (require (for-label (prefix-in gui: racket/gui)))

which I wanted to avoid here: I didn't want all references to net/cookies/server to use the net: prefix.

[1]: https://docs.racket-lang.org/gui-easy/index.html