### PR TITLE
Change private key loading to default to PEM-encoded PKCS#8

### DIFF
--- a/web-server-doc/web-server/scribblings/launch.scrbl
+++ b/web-server-doc/web-server/scribblings/launch.scrbl
@@ -193,7 +193,9 @@ A default implementation of the dispatch server's connection-conversion abstract
 
 Constructs an implementation of the dispatch server's connection-conversion abstraction for OpenSSL.
 
-@history[#:added "1.1"]}
+@history[#:changed "8.16"
+         @elem{Changed the handling of private keys to support the PEM-encoded PKCS#8 format by default.}
+         #:added "1.1"]}
 
 
 @defproc[(do-not-return) none/c]{

--- a/web-server-lib/web-server/web-server.rkt
+++ b/web-server-lib/web-server/web-server.rkt
@@ -74,7 +74,7 @@
   (define the-ctxt
     (ssl-make-server-context))
   (ssl-load-certificate-chain! the-ctxt server-cert-file)
-  (ssl-load-private-key! the-ctxt server-key-file)
+  (ssl-load-private-key! the-ctxt server-key-file #f)
   (define-unit ssl:dispatch-server-connect@
     (import) (export dispatch-server-connect^)
     (define (port->real-ports ip op)


### PR DESCRIPTION
Simpler change to support LetsEncrypt keys in the webserver. See https://github.com/racket/web-server/pull/137 for more discussion. If someone has better copy for the documentation, I would be happy to change it. I have tested this for my use case and it works, but I would also be willing to add tests if there is a good way to test this.

cc @LiberalArtist @rmculpepper 